### PR TITLE
issue#28 fix: 修正 users/profiles 缺失傳入參數錯誤

### DIFF
--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -8,11 +8,10 @@
             <li><a href="{% url 'products:index' %}">商品</a></li>
             <li><a href="{% url 'sales:index' %}">銷售頁面</a></li>
             <li><a href="{% url 'status:index' %}">團購狀態</a></li>
-            <li><a href="{% url 'users:profiles' %}">用戶頁面</a></li>
         </ul>
         {% if user.is_authenticated %}
             <ul class="flex gap-4">
-                <li><a href="{% url 'users:new' %}">{{user.username}}</a></li>
+                <li><a href="{% url 'users:profiles'%}">{{user.username}}</a></li>
                 <li><a href="{% url 'users:sessions_delete' %}?next={{request.path}}">登出</a></li>
             </ul>
         {% else %}

--- a/users/urls.py
+++ b/users/urls.py
@@ -4,7 +4,7 @@ from . import views
 app_name = "users"
 
 urlpatterns = [
-    path('profiles/<int:id>', views.profiles, name="profiles"),
+    path('profiles', views.profiles, name="profiles"),
     path("new/", views.new, name="new"),
     path("", views.create, name="create"),
     path("sessions/new/", views.sessions_new, name="sessions_new"),

--- a/users/views.py
+++ b/users/views.py
@@ -183,8 +183,9 @@ def verify_email(request, uid, token):
         messages.error(request, "無效的驗證連結。如果您尚未註冊，請先註冊帳號")
         return redirect("users:new")
 
-def profiles(request, id):
-    user = get_object_or_404(User, pk=id)
+@login_required
+def profiles(request):
+    user = request.user
     user_address = get_object_or_404(UserAddress, user=user)
     user_form = UserForm(instance=user)
     user_address_form = UserAddressForm(instance=user_address)


### PR DESCRIPTION
#28 

用戶頁面由於只能查看自己，故改成不需傳入 user.id 參數，路徑調整爲 users/profiles

當前爲需要登入後才能訪問，
如圖片中點擊名稱即可跳轉至用戶頁面。

<img width="1440" height="405" alt="Image" src="https://github.com/user-attachments/assets/56a876ce-1f96-4e9f-b95f-ca679befe8a0" />