### PR TITLE
issue#56 新增 產品新增頁面

### DIFF
--- a/groups/templates/groups/edit_group.html
+++ b/groups/templates/groups/edit_group.html
@@ -7,6 +7,7 @@
     {% csrf_token %}
     {{ group_form.as_div }}
     <button class="border-1" type="submit">更新</button>
+    <a class="border" href="{% url 'products:product_create' group.id %}">新增產品</a>
   </form>
 </div>
 

--- a/products/forms.py
+++ b/products/forms.py
@@ -1,0 +1,32 @@
+from django.forms import ModelForm
+from .models import Product
+from django.forms.widgets import TextInput, NumberInput, Textarea
+
+
+class ProductForm(ModelForm):
+  class Meta:
+    model = Product
+    fields = ['name', 'price', 'description']
+    labels = {
+        'name': '產品名稱',
+        'price': '產品價格',
+        'description': '產品描述'
+    }
+    widgets = {
+        'name': TextInput(attrs={
+            'class': 'w-full border-2 border-gray-300 rounded-md p-2',
+            'placeholder': '產品名稱',
+            'required': True
+        }),
+        'price': NumberInput(attrs={
+            'class': 'w-full border-2 border-gray-300 rounded-md p-2',
+            'placeholder': '產品價格',
+            'required': True
+        }),
+        'description': Textarea(attrs={
+            'class': 'w-full border-2 border-gray-300 rounded-md p-2 resize-y',
+            'placeholder': '產品描述',
+            'rows': 5,
+            'required': True
+        })
+    }

--- a/products/templates/products/product_create.html
+++ b/products/templates/products/product_create.html
@@ -1,0 +1,13 @@
+{% extends 'layouts/default.html' %}
+
+{% block content %}
+<div>
+  <h1 class="text-2xl font-bold text-center">座標位置：products / product_create</h1>
+</div>
+<form method="post" enctype="multipart/form-data">
+  {% csrf_token %}
+  {{ product_form.as_div }}
+  <button class="border">新增產品</button>
+</form>
+
+{% endblock %}

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,4 +1,3 @@
-from django.contrib import admin
 from django.urls import path
 from . import views
 
@@ -8,4 +7,5 @@ app_name = "products"
 urlpatterns = [
     path("", views.index, name="index"),
     path("<int:product_id>/", views.product_detail, name="product_detail"),
+    path("product_create/<int:group_id>", views.product_create, name="product_create"),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -1,5 +1,8 @@
 from django.shortcuts import render, get_object_or_404
-from .models import Product, ProductImage
+from .models import Product, ProductImage, Group
+from .forms import ProductForm
+from django.contrib import messages
+from django.shortcuts import redirect
 
 
 def index(request):
@@ -12,3 +15,21 @@ def product_detail(request, product_id):
         Product.objects.select_related("group").prefetch_related("images"), pk=product_id
     )
     return render(request, "products/product_detail.html", {"product": product})
+
+
+def product_create(request, group_id):
+    group = get_object_or_404(Group, pk=group_id)
+    if request.method == 'POST':
+        product_form = ProductForm(request.POST)
+        if product_form.is_valid():
+            data = product_form.save(commit=False)
+            data.group = group
+            data.save()
+            messages.success(request, "產品已建立")
+            return redirect('products:index')
+        else:
+            print(product_form.errors)
+            messages.warning(request, "欄位填寫有誤，請檢查後再試")
+            return redirect('products:product_create', group_id)
+    product_form = ProductForm()
+    return render(request, "products/product_create.html", {"product_form": product_form})


### PR DESCRIPTION
close #56 
- 在`groups/edit_group.html`裡面建立了`product_create`的入口，但這個功能還是寫在 products 目錄下面，如果要將兩個不同model的東西合併在一個Form裡提交，就算是跨App的表單組合，會比較花費時間。

- 另外還沒有產品圖片上傳功能，因為在Model建立時，產品圖片跟產品資訊處於不同的Table。
  - 如果跟開團頁面的Banner一樣在同一個Table會好處理
  - 如果分開Table就可以維持一對多，一個產品多張圖片，就需要再看一下Django文件有沒有其他處理方法。
  - 之後可能會使用：`Formset`、`InlineFormset`