### PR TITLE
Feat#83 註冊登入流程更新

### DIFF
--- a/BuyBuddy/settings.py
+++ b/BuyBuddy/settings.py
@@ -162,15 +162,15 @@ ANYMAIL = {
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
 
-#AWS & S3 setting
-STORAGES = { 
-    "default": { 
+# AWS & S3 setting
+STORAGES = {
+    "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
-        },
-        "staticfiles": {
-          "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-        },
-    }
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")

--- a/src/scripts/messages.js
+++ b/src/scripts/messages.js
@@ -11,6 +11,8 @@ const infoColor = bgList["info"];
 const messagesControl = () => {
   return {
     items: [],
+    modal: { show: false, title: "", text: "", type: "" },
+    hasShownVerify: false,
 
     showAllFrom(jsonRef) {
       if (!jsonRef) {
@@ -43,7 +45,29 @@ const messagesControl = () => {
         messages.forEach(({ text, tag }) => {
           if (!text) return;
 
-          const type = (tag || "info").split(" ")[0];
+          const tagsStr = String(tag || "");
+          const isVerify = tagsStr.includes("verify");
+          const fromRegister = tagsStr.includes("register");
+          const fromProfile = tagsStr.includes("profile");
+          const isSuccess = tagsStr.includes("success");
+
+          if (!this.hasShownVerify && isVerify) {
+            let title = "通知";
+            if (fromRegister) {
+              title = "註冊＆登入成功";
+            } else if (fromProfile) {
+              title = isSuccess ? "已寄出驗證信" : "驗證信寄送失敗";
+            }
+
+            this.modal.title = title;
+            this.modal.text = text;
+            this.modal.type = isSuccess ? "success" : "warning";
+            this.modal.show = true;
+            this.hasShownVerify = true;
+            return;
+          }
+
+          const type = tagsStr.split(" ")[0] || "info";
           const bg = bgList[type] || infoColor;
 
           // DEVLOG: Toastify 內容

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4,6 +4,7 @@
 
 :root {
   font-family: "Montserrat";
+  --bg-color: #f8f5ed;
   --main-color: #ebbc46;
   --brand-red: #d85c34;
   --brand-green: #3d7757ff;
@@ -11,7 +12,7 @@
 }
 
 html {
-  background: #f8f5ed;
+  background: var(--bg-color);
   color: var(--brand-black);
 }
 

--- a/templates/shared/messages.html
+++ b/templates/shared/messages.html
@@ -1,11 +1,28 @@
 {% if messages %}
-<div x-data="messagesControl" x-init="showAllFrom($refs.msgsJson)">
-    <script type="application/json" x-ref="msgsJson">
-    [
-        {% for message in messages %}
-            {"text":"{{ message|escapejs }}","tag":"{{ message.tags|escapejs }}"} {% if not forloop.last %},{% endif %}
-        {% endfor %}
-    ]
-    </script>
-</div>
+        <div x-data="messagesControl" x-init="showAllFrom($refs.msgsJson)">
+            <script type="application/json" x-ref="msgsJson">
+            [
+                {% for message in messages %}
+                    {"text":"{{ message|escapejs }}","tag":"{{ message.tags|escapejs }}"} {% if not forloop.last %},{% endif %}
+                {% endfor %}
+            ]
+            </script>
+
+            <div x-cloak
+                x-show="modal.show"
+                x-transition
+                class="fixed inset-0 bg-black/60 flex items-center justify-center z-10 text-center">
+                <div class="rounded-4xl shadow-xl max-w-md relative pt-20 pb-14 px-14 "
+                     :class="modal.type == 'success'? 'bg-[var(--main-color)]':'bg-[var(--brand-red)]'
+                ">
+                    <p x-text="modal.title" class="text-2xl font-bold"></p>
+                    <button class="absolute top-6 right-6 cursor-pointer 
+                    hover:outline hover:outline-[1.5px] hover:outline-offset-8 rounded-full transition-all"
+                    @click="modal.show=false">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#000000" viewBox="0 0 256 256"><path d="M208.49,191.51a12,12,0,0,1-17,17L128,145,64.49,208.49a12,12,0,0,1-17-17L111,128,47.51,64.49a12,12,0,0,1,17-17L128,111l63.51-63.52a12,12,0,0,1,17,17L145,128Z"></path></svg>
+                    </button>
+                    <p class="text-brand-black my-4" x-text="modal.text"></p>
+                </div>
+            </div>
+        </div>
 {% endif %}

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,10 +1,76 @@
-from django.forms import ModelForm, FileInput, TextInput, PasswordInput, CheckboxInput, NumberInput
+from django.forms import (
+    ModelForm,
+    FileInput,
+    TextInput,
+    CheckboxInput,
+    NumberInput,
+)
 from .models import User, UserAddress
+from django import forms
+from django.core.validators import MinLengthValidator
+
+
+class RegistrationForm(ModelForm):
+    class Meta:
+        model = User
+        fields = ["username", "email", "password"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # 幫密碼加上最小長度驗證器
+        self.fields["password"].validators.append(
+            MinLengthValidator(8, message="密碼至少需要 8 個字符。")
+        )
+
+        self.fields["password"].min_length = 8
+
+        # 自定義錯誤訊息
+        self.fields["username"].error_messages = {
+            "required": "請輸入用戶名。",
+        }
+        self.fields["email"].error_messages = {
+            "required": "請輸入電子郵件地址。",
+            "invalid": "請輸入有效的電子郵件地址。",
+        }
+        self.fields["password"].error_messages = {
+            "required": "請輸入密碼。",
+        }
+
+    def clean_email(self):
+        # 檢查 email 是否已存在
+        email = self.cleaned_data.get('email')
+        if email and User.objects.filter(email=email).exists():
+            raise forms.ValidationError("此 Email 已被註冊，請使用其他信箱。")
+        return email
+
+    def clean_username(self):
+        # 檢查 username 是否已存在
+        username = self.cleaned_data.get('username')
+        if username and User.objects.filter(username=username).exists():
+            raise forms.ValidationError("此用戶名已被使用，請選擇其他用戶名。")
+        return username
+
+
+class LoginForm(forms.Form):
+    email = forms.EmailField(
+        error_messages={
+            "required": "請輸入電子郵件地址。",
+            "invalid": "請輸入有效的電子郵件地址。",
+        }
+    )
+
+    password = forms.CharField(
+        error_messages={
+            "required": "請輸入密碼。",
+        }
+    )
+
 
 class UserForm(ModelForm):
     class Meta:
         model = User
-        fields = [ "avatar_url", "username"]
+        fields = ["avatar_url", "username"]
         labels = {
             "avatar_url": "大頭照",
             "username": "用戶名稱",
@@ -14,30 +80,37 @@ class UserForm(ModelForm):
             "username": TextInput(),
         }
 
+
 class UserAddressForm(ModelForm):
     class Meta:
         model = UserAddress
-        fields = [ "recipient_name", "is_default", "phone", "postal_code", "county", "district", "road", "detail" ]
+        fields = [
+            "recipient_name",
+            "is_default",
+            "phone",
+            "postal_code",
+            "county",
+            "district",
+            "road",
+            "detail",
+        ]
         labels = {
-            "recipient_name": "收件人姓名", 
+            "recipient_name": "收件人姓名",
             "is_default": "設爲預設",
-            "phone": "收件人手機", 
-            "postal_code": "郵遞區號", 
-            "county": "縣市", 
-            "district": "鄉鎮市區", 
-            "road": "住址1", 
+            "phone": "收件人手機",
+            "postal_code": "郵遞區號",
+            "county": "縣市",
+            "district": "鄉鎮市區",
+            "road": "住址1",
             "detail": "住址2",
         }
         widgets = {
             "recipient_name": TextInput(),
             "is_default": CheckboxInput(),
-            "phone": NumberInput(), 
+            "phone": NumberInput(),
             "postal_code": NumberInput(),
-            "county": TextInput(), 
+            "county": TextInput(),
             "district": TextInput(),
             "road": TextInput(),
             "detail": TextInput(),
-
         }
-
-

--- a/users/templates/users/new.html
+++ b/users/templates/users/new.html
@@ -7,27 +7,54 @@
         <img class="w-30 mt-12 mx-auto" src="{% static "asset/buddy_1.svg" %}" alt="">
         <h1 class="text-2xl font-bold mt-5 mb-2 text-center">註冊</h1>
         <h1 class="text-lg font-bold mb-8 text-center">Be Our Buddy!</h1>
-        <form action="{% url 'users:create' %}" method="post" class="space-y-8">
+        <form action="{% url 'users:create' %}" method="post" class="space-y-8" novalidate>
             {% csrf_token %}
             <div class="space-y-2">
-                <div class="relative">
+                <div class="relative h-15">
+                    <svg class="absolute left-0 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#000000" viewBox="0 0 256 256"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"></path></svg>
+                    <input type="text" 
+                           placeholder="請輸入用戶名" 
+                           name="username" 
+                           class="w-full h-15 pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors"
+                           value="{{form.username.value|default:''}}">
+                    {% if form.username.errors %}
+                        <div class="text-[var(--brand-red)] text-sm ml-8 mt-2">
+                            {{ form.username.errors.0 }}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="space-y-2">
+                <div class="relative h-15">
                     <svg class="absolute left-0 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#221b18" viewBox="0 0 256 256"><path d="M224,48H32a8,8,0,0,0-8,8V192a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A8,8,0,0,0,224,48ZM203.43,64,128,133.15,52.57,64ZM216,192H40V74.19l82.59,75.71a8,8,0,0,0,10.82,0L216,74.19V192Z"></path></svg>
                     <input type="email" 
                            placeholder="請輸入信箱" 
                            name="email" 
-                           class="w-full h-15 pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors">
+                           class="w-full h-15 pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors"
+                           value="{{form.email.value|default:''}}">
+                    {% if form.email.errors %}
+                        <div class="text-[var(--brand-red)] text-sm ml-8 mt-2">
+                            {{ form.email.errors.0 }}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             <div class="space-y-2">
-                <div class="relative">
+                <div class="relative h-15">
                     <svg class="absolute left-0 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#221b18" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
                     <input type="password" 
                            placeholder="請輸入密碼" 
                            name="password" 
-                           class="w-full h-15  pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors">
+                           class="w-full h-15  pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors"
+                           value="{{form.password.value|default:''}}">
+                    {% if form.password.errors %}
+                        <div class="text-[var(--brand-red)] text-sm ml-8 mt-2">
+                            {{ form.password.errors.0 }}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
-            <div class="flex justify-center">
+            <div class="flex justify-center mt-12">
                 <button class="text-brand-black px-12 py-3 rounded-full border-[1.2px]  hover:bg-[var(--main-color)] [&:hover]:border-[var(--main-color)] transition-all ease-in-out cursor-pointer">
                 註冊
                 </button>

--- a/users/templates/users/sessions_new.html
+++ b/users/templates/users/sessions_new.html
@@ -7,28 +7,39 @@
         <img class="w-30 mt-12 mx-auto" src="{% static "asset/buddy_2.svg" %}" alt="">
         <h1 class="text-2xl font-bold mt-5 mb-2 text-center">登入</h1>
         <h1 class="text-lg font-bold mb-8 text-center">Buy Together, Save Forever!</h1>
-        <form action="{% url 'users:sessions_create' %}" method="post" class="space-y-8">
+        <form action="{% url 'users:sessions_create' %}" method="post" class="space-y-8" novalidate>
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.GET.next }}">
             <div class="space-y-2">
-                <div class="relative">
+                <div class="relative h-15">
                                         <svg class="absolute left-0 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#221b18" viewBox="0 0 256 256"><path d="M224,48H32a8,8,0,0,0-8,8V192a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A8,8,0,0,0,224,48ZM203.43,64,128,133.15,52.57,64ZM216,192H40V74.19l82.59,75.71a8,8,0,0,0,10.82,0L216,74.19V192Z"></path></svg>
-                    <input type="text" 
+                    <input type="email" 
                            placeholder="請輸入信箱" 
                            name="email" 
+                           value="{{form.email.value|default:''}}"
                            class="w-full h-15 pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors bg-transparent [&:-webkit-autofill]:!bg-[#ece7d9] [&:-webkit-autofill]:shadow-[0_0_0_100px_#ece7d9_inset] ">
+                    {% if form.email.errors %}
+                        <div class="text-[var(--brand-red)] text-sm ml-8 mt-2">
+                            {{ form.email.errors.0 }}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             <div class="space-y-2">
-                <div class="relative">
+                <div class="relative h-15">
                     <svg class="absolute left-0 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#221b18" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
                     <input type="password" 
                            placeholder="請輸入密碼" 
                            name="password" 
                            class="w-full h-15 pl-8 pr-1 py-2 border-b-[1.2px] border-brand-black focus:outline-none transition-colors bg-transparent [&:-webkit-autofill]:!bg-[#ece7d9] [&:-webkit-autofill]:shadow-[0_0_0_100px_#ece7d9_inset] ">
+                    {% if form.password.errors %}
+                        <div class="text-[var(--brand-red)] text-sm ml-8 mt-2">
+                            {{ form.password.errors.0 }}
+                        </div>
+                    {% endif %}
                 </div>
             </div>
-            <div class="flex items-center space-x-2 mt-4">
+            <div class="flex items-center space-x-2 mt-12">
                 <label class="relative w-6 h-6 cursor-pointer flex items-center">
                     <input type="checkbox" 
                            id="remember_me" 

--- a/users/views.py
+++ b/users/views.py
@@ -68,11 +68,15 @@ def create(request):
         success = send_verification_mail(request, new_user, new_user.email)
         if success:
             messages.success(
-                request, "註冊成功，驗證信已發送，請至您的信箱點擊驗證連結"
+                request,
+                "驗證信已發送，請至您的信箱點擊驗證連結",
+                extra_tags="verify register",
             )
         else:
             messages.warning(
-                request, "註冊成功，但驗證信寄送失敗，請稍後到個人設定重新寄送"
+                request,
+                "但驗證信發送失敗，請稍後至個人頁面驗證",
+                extra_tags="verify register",
             )
 
         login(request, new_user)
@@ -105,10 +109,6 @@ def sessions_create(request):
     password = form.cleaned_data.get("password")
     remember_me = "remember_me" in request.POST
 
-    # if not email or not password:
-    #     messages.warning(request, "缺少登入資料")
-    #     return redirect("users:sessions_new")
-
     user = authenticate(request, username=email, password=password)
     if user:
         login(request, user)
@@ -139,20 +139,28 @@ def sessions_delete(request):
     return redirect("pages:homepage")
 
 
+@login_required
 def check_email(request):
     # TODO: 個人頁面需要二次驗證
-    if request.user.is_authenticated:
-        user = request.user
+    user = request.user
 
     if user.is_verified:
         messages.info(request, "您的信箱已經驗證過了")
         return redirect("users:profiles")
 
     success = send_verification_mail(request, user, user.email)
-    if not success:
-        messages.success(request, "驗證信已發送，請至您的信箱點擊驗證連結")
+    if success:
+        messages.success(
+            request,
+            "請至您的信箱點擊驗證連結",
+            extra_tags="verify profile",
+        )
     else:
-        messages.warning(request, "寄送驗證信失敗，請稍後再試")
+        messages.warning(
+            request,
+            "請稍後再試",
+            extra_tags="verify profile",
+        )
 
     return redirect("users:profiles")
 

--- a/users/views.py
+++ b/users/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_str
 from django.urls import reverse
-from .forms import UserForm, UserAddressForm
+from .forms import UserForm, UserAddressForm, RegistrationForm, LoginForm
 from anymail.message import AnymailMessage
 
 
@@ -41,51 +41,47 @@ def send_verification_mail(request, user, email):
         return False
 
 
-@login_required
-def detail(request):
-    return render(request, "users/detail.html")
-
-
 def new(request):
     if request.user.is_authenticated:
         messages.info(request, "您已經登入了")
         return redirect("pages:homepage")
-    return render(request, "users/new.html")
+    form = RegistrationForm()
+    return render(request, "users/new.html", {"form": form})
 
 
 @require_POST
 def create(request):
-    email = request.POST.get("email")
-    password = request.POST.get("password")
-
-    if not email or not password:
-        messages.warning(request, "缺少註冊資料")
-        return redirect("users:new")
+    form = RegistrationForm(request.POST)
+    if not form.is_valid():
+        return render(request, "users/new.html", {"form": form})
 
     try:
         # 先建立用戶資料
-        new_user = User.objects.create_user(
-            username=email,
-            email=email,
-            password=password,
-            avatar_url='image/upload/v1755754867/avatars/tyzned8ajzgzeokgarve.png',
+        new_user = form.save(commit=False)
+        new_user.avatar_url = (
+            'image/upload/v1755754867/avatars/tyzned8ajzgzeokgarve.png'
         )
+        new_user.set_password(form.cleaned_data["password"])  # 手動雜湊密碼
+        new_user.save()
 
         # 寄信
-        success = send_verification_mail(request, new_user, email)
-        if not success:
-            messages.warning(request, "寄送驗證信失敗，請登入後稍後再試")
-            return redirect("users:sessions_new")
-        return redirect("users:check_email")
+        success = send_verification_mail(request, new_user, new_user.email)
+        if success:
+            messages.success(
+                request, "註冊成功，驗證信已發送，請至您的信箱點擊驗證連結"
+            )
+        else:
+            messages.warning(
+                request, "註冊成功，但驗證信寄送失敗，請稍後到個人設定重新寄送"
+            )
 
-    except IntegrityError:
-        messages.error(request, "此 Email 已註冊")
-        return redirect("users:new")
+        login(request, new_user)
+        return redirect("pages:homepage")
 
     except Exception as e:
         print(f"註冊時發生錯誤: {e}")
         messages.error(request, "註冊失敗，請稍後再試")
-        return redirect("users:new")
+        return render(request, "users/new.html", {"form": form})
 
 
 def sessions_new(request):
@@ -94,18 +90,24 @@ def sessions_new(request):
         return redirect("pages:homepage")
     if request.GET.get("next"):
         messages.warning(request, "請先登入，以繼續訪問頁面")
-    return render(request, "users/sessions_new.html")
+
+    form = LoginForm()
+    return render(request, "users/sessions_new.html", {"form": form})
 
 
 @require_POST
 def sessions_create(request):
-    email = request.POST.get("email")
-    password = request.POST.get("password")
+    form = LoginForm(request.POST)
+    if not form.is_valid():
+        return render(request, "users/sessions_new.html", {"form": form})
+
+    email = form.cleaned_data.get("email")
+    password = form.cleaned_data.get("password")
     remember_me = "remember_me" in request.POST
 
-    if not email or not password:
-        messages.warning(request, "缺少登入資料")
-        return redirect("users:sessions_new")
+    # if not email or not password:
+    #     messages.warning(request, "缺少登入資料")
+    #     return redirect("users:sessions_new")
 
     user = authenticate(request, username=email, password=password)
     if user:
@@ -120,9 +122,10 @@ def sessions_create(request):
             return redirect(next_url)
         messages.success(request, "登入成功")
         return redirect("pages:homepage")
+
     else:
         messages.error(request, "帳號或密碼錯誤")
-        return redirect("users:sessions_new")
+        return render(request, "users/sessions_new.html", {"form": form})
 
 
 def sessions_delete(request):
@@ -141,19 +144,17 @@ def check_email(request):
     if request.user.is_authenticated:
         user = request.user
 
-        if user.is_verified:
-            messages.info(request, "您的信箱已經驗證過了")
-            return redirect("users:detail")
+    if user.is_verified:
+        messages.info(request, "您的信箱已經驗證過了")
+        return redirect("users:profiles")
 
-        success = send_verification_mail(request, user, user.email)
-        if not success:
-            messages.warning(request, "寄送驗證信失敗，請稍後再試")
-            return redirect("users:detail")
-
+    success = send_verification_mail(request, user, user.email)
+    if not success:
         messages.success(request, "驗證信已發送，請至您的信箱點擊驗證連結")
-        return redirect("users:detail")
+    else:
+        messages.warning(request, "寄送驗證信失敗，請稍後再試")
 
-    return render(request, "users/check_email.html")
+    return redirect("users:profiles")
 
 
 def verify_email(request, uid, token):


### PR DESCRIPTION
close #83 
- 將註冊改用 ModelForms 控制，且新增自定義錯誤訊息顯示
- 將登入改用 Form 控制，且新增自定義錯誤訊息顯示
- 將認證信獨立 template 刪除，改用彈窗顯示
- 更新 messages.js 邏輯，以便彈窗顯示
- 留下 check_mail urls 供個人頁面二次發送驗證信