### PR TITLE
issue#76: 團購頁面改善，將 views.py 的顯示邏輯移至 forms.pyrefactor重構

### DIFF
--- a/groups/forms.py
+++ b/groups/forms.py
@@ -87,6 +87,16 @@ class ProductForm(ModelForm):
         'required': True,
       }),
     }
+  def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # 只有在編輯現有物件時才鎖定欄位
+        if self.instance and self.instance.pk:
+            exclude_fields = ['deadline', 'min_goal']
+            for field_name, field in self.fields.items():
+                if field_name not in exclude_fields:
+                    field.widget.attrs['readonly'] = True
+                    field.widget.attrs['class'] += ' cursor-not-allowed'  
+
 
 class ProductImageForm(ModelForm):
   class Meta:
@@ -102,3 +112,4 @@ class ProductImageForm(ModelForm):
         'required': True,
       }),
     }
+  

--- a/groups/views.py
+++ b/groups/views.py
@@ -73,16 +73,8 @@ def edit_group(request, id):
     else:
       messages.warning(request, "您無權編輯此團購")
       return redirect('groups:read_group')
-
-  exclude_fields = ['deadline', 'min_goal']
-  for field_name, field in group_form.fields.items():
-    if field_name not in exclude_fields:
-      field.widget.attrs.update({
-        'class': 'w-full border-2 border-gray-300 rounded-md p-2 cursor-not-allowed',
-        'readonly': 'readonly',
-      })
-  
   return render(request, 'groups/edit_group.html', {'group_form': group_form, 'group': group, 'product_form': product_form, 'productImage_form': productImage_form})
+  
 
 @login_required
 def delete_group(request, id):


### PR DESCRIPTION
close #76 

## 此PR的改善關於「關注點分離」
關注點分離是一種軟體設計原則，意思是「不同的功能或責任應該由不同的程式碼模組處理」。這樣可以讓每個模組只專注於自己的任務，減少耦合度，提高可讀性、可維護性。

- `forms.py`：負責表單結構的定義、邏輯驗證和資料模型的互動
- `views.py`：負責 HTTP 請求流程控制、頁面渲染、呼叫 forms 處理資料
