### PR TITLE
fix #117 : 解決groups/new 欄位互相覆蓋資料 & 刪除團購功能失效

### DIFF
--- a/groups/templates/groups/manage.html
+++ b/groups/templates/groups/manage.html
@@ -10,6 +10,7 @@
 	<form action="{% url 'groups:owned' %}" method="post">
 	{% csrf_token %}
 		<input type="hidden" name="_method" value="delete">
+        <input type="hidden" name="group-id" value="{{ group.id }}">
 		<button>刪團</button>
 	</form>
 	

--- a/groups/views.py
+++ b/groups/views.py
@@ -13,8 +13,8 @@ def index(request):
 	return render(request, "groups/index.html", {"groups": groups})
 
 def new(request):
-	product_form = ProductForm()
-	group_form = GroupForm()
+	product_form = ProductForm(prefix='product')
+	group_form = GroupForm(prefix='group')
 	productImage_form = ProductImageForm()
 	return render(request, 'groups/new.html', {'product_form': product_form, 'group_form': group_form, 'productImage_form': productImage_form})
 
@@ -32,8 +32,8 @@ def owned(request):
 			messages.success(request, "團購已刪除")
 			return redirect('groups:owned')
 
-		group_form = GroupForm(request.POST, request.FILES)
-		product_form = ProductForm(request.POST)
+		group_form = GroupForm(request.POST, request.FILES, prefix='group')
+		product_form = ProductForm(request.POST, prefix='product')
 		productImage_form = ProductImageForm(request.POST, request.FILES)
 
 		if group_form.is_valid() and product_form.is_valid() and productImage_form.is_valid():


### PR DESCRIPTION
close #117 
- 解決`groups/new` 欄位`groups` 跟 `products` 的 `name`跟`description`欄位資料互相覆蓋的問題。
  - 在`views.py`的`def new`、`def owned`函式裡，表單實例化時為每個表單添加了前綴參數`prefix`。
- 解決`manage.html`**刪團**按鍵失效的問題。
  - `manage.html`的**刪團**按鍵上增加傳送`group.id`。
    ```html
    <!-- Line 13 -->
    <input type="hidden" name="group-id" value="{{ group.id }}">
    ```