### PR TITLE
style#138: 優化我跟團/開團的訂單樣式(RWD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ public/scripts/*
 
 staticfiles
 celerybeat-schedule
+buybuddy_db.sql

--- a/groups/forms.py
+++ b/groups/forms.py
@@ -9,10 +9,7 @@ from django.conf import settings
 
 class GroupForm(ModelForm):
   goal_choice = forms.ChoiceField(
-    choices=[
-          ('1', '金額'),
-          ('2', '數量')
-      ],
+    choices=Group.GOAL_CHOICES,
       label='成團方式'
   )
   class Meta:

--- a/groups/models.py
+++ b/groups/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from users.models import User
 from tinymce.models import HTMLField
 from django_fsm import FSMField, transition
+from django.db.models import Sum, F
 
 
 class Group(models.Model):
@@ -77,3 +78,5 @@ class JoinedGroup(models.Model):
 
     def __str__(self) -> str:
         return f"{self.buyer.username} joined {self.group.name}"
+
+    updated_at = models.DateTimeField(auto_now=True, null=True, blank=True)

--- a/orders/models.py
+++ b/orders/models.py
@@ -108,15 +108,6 @@ class Order(models.Model):
         """檢查訂單是否已完成"""
         return self.order_status == self.OrderStatus.COMPLETED
 
-    def save(self, *args, **kwargs):
-        if not self.pk or not self.order_number:
-            self.order_number = _generate_unique_number()
-        super().save(*args, **kwargs)
-
-    @property
-    def formatted_amount(self):
-        return f"{self.amount:,.0f}"
-
     def apply_address(self, address: UserAddress, *, save=True):
         if address.user_id != self.user_id:
             raise ValidationError("地址不屬於該訂單的使用者")

--- a/orders/templates/orders/my_orders/list.html
+++ b/orders/templates/orders/my_orders/list.html
@@ -1,157 +1,166 @@
-<div class="max-w-[1280px] mx-auto px-10 py-12">
-{% if joined_groups or orders%}
+{% load humanize %}
+<div class="mx-auto px-10 py-12">
+	{% if joined_groups or orders%}
 	{# 尚未成團：joined_groups #}
 	{% if joined_groups %}
-		<section class="mb-10">
-			<h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未成團</h2>
-			<div class="overflow-x-auto bg-transparent rounded-2xl border border-gray-300">
-				<table class="min-w-full border-collapse table-fixed text-sm" style="border-spacing:0">
-					<colgroup>
-						<col style="width:340px;" /> <!-- 團購/訂單(含圖) -->
-						<col style="width:373px;" /> <!-- 商品 -->
-						<col style="width:97px;" /> <!-- 價格 -->
-						<col style="width:65px;" /> <!-- 數量 -->
-						<col style="width:97px;" /> <!-- 小計 -->
-						<col style="width:97px;" /> <!-- 合計 -->
-						<col style="width:97px;" /> <!-- 狀態 -->
-						<col style="width:113px;" /> <!-- 操作 -->
-					</colgroup>
-					<thead class="bg-transparent">
-						<tr>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[340px]">團購 / 訂單</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[373px]">商品</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">價格</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[65px]">數量</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">小計</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">合計</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">狀態</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[113px]">操作</th>
-						</tr>
-					</thead>
-					<tbody class="bg-transparent">
-							{% for jg in joined_groups %}
-							<tr class="border-t border-gray-300 hover:bg-transparent transition">
-								<td class="px-4 py-8 align-top text-sm font-medium text-gray-900 w-[340px]">
-									<div class="flex items-center gap-3"> <!-- 團名與圖片水平對齊 -->
-										<div class="w-12 h-12 bg-transparent overflow-hidden rounded border border-gray-300 flex-shrink-0">
-											{% if jg.group.banner %}
-												<img src="{{ jg.group.banner.url }}" alt="{{ jg.group.name }}" class="w-full h-full object-cover object-center block">
-											{% else %}
-												<div class="w-full h-full bg-transparent"></div>
-											{% endif %}
-										</div>
-										<div class="text-base font-semibold text-gray-900 mt-1 truncate">{{ jg.group.name }}</div>
-									</div>
-								</td>
+	<section class="max-w-[1440px] mx-auto md:px-16 sm:px-24 mt-12 lg:mt-16">
+		<h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未成團</h2>
+			{% for jg in joined_groups %}
+			
+			<div class="bg-white rounded-2xl border border-gray-300 p-6 mb-4 shadow-sm hover:shadow-md transition-shadow">
+				
+				<div class="flex flex-col lg:flex-row gap-6">
 
+					<!-- 圖片區域 -->
+					<div class="flex-shrink-0">
+						<div class="w-full h-48 lg:h-64 lg:w-64 rounded-lg border border-gray-200 overflow-hidden">
+							{% if jg.group.banner %}
+							<img class="w-full h-full object-cover object-center" src="{{ jg.group.banner.url }}" alt="{{ jg.group.name }}">
+							{% else %}
+							<div class="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400">
+								<span>無圖片</span>
+							</div>
+							{% endif %}
+						</div>
+					</div>
+					
+					<!-- 內容區域 -->
+					<div class="flex-1 flex flex-col gap-4">
+						<div class="flex-col sm:flex-row  flex justify-between items-start sm:items-center">
+							<h2 class="text-lg sm:text-2xl text-center md:text-left font-semibold text-gray-900">{{ jg.group.name }}</h2>
+							<p class="text-sm text-right text-red-500 mb-2">未成團</p>
+						</div>
+						
+						<div class="space-y-3" >
+							<ul class="min-h-[130px]">
+								<li class="grid grid-cols-1 md:grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center p-2">
+									<p class="text-sm text-gray-600">商品</p>
+									<p class="hidden md:grid grid-cols-3 gap-4 text-sm text-gray-600">
+										<span>價格</span>
+										<span>數量</span>
+										<span>小計</span>
+									</p>
+								</li>
 								{% include 'orders/my_orders/list_columns.html' with items=jg.joined_group_products.all %}
-
-								<td class="px-4 py-8 align-top text-left text-lg font-semibold text-gray-900 w-[97px]">-</td>
-
-								<td class="px-4 py-8 align-top text-left text-sm text-yellow-700 w-[97px]">未成團</td>
-
-								<td class="px-4 py-8 align-top text-left w-[113px]">
-									<div class="flex flex-row flex-wrap items-start justify-start gap-2">
-										<a href="#" class="px-2 py-1 rounded-full border border-gray-300 text-sm text-gray-800 whitespace-nowrap">修改跟團</a>
-										{% comment %} #TODO 退團連結 {% endcomment %}
-										<form action="#" method="post" class="inline">
-											{% csrf_token %}
-											<input type="hidden" name="_method" value="delete" />
-											<input type="hidden" name="group-id" value="{{ jg.group.id }}" />
-											<button type="submit" class="px-2 py-1 rounded-full border border-red-300 text-sm text-red-700 hover:bg-red-50 whitespace-nowrap">退團</button>
-										</form>
-									</div>
-								</td>
-							</tr>
-						{% endfor %}
-					</tbody>
-				</table>
+								<li class="hidden md:grid grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+									<p class="grid col-start-2 grid-cols-3 gap-4 text-base font-semibold text-gray-900">
+										<span class="col-start-2">合計</span>
+										<span>
+											${{ jg.total_amount | intcomma }}
+										</span>
+									</p>
+								</li>
+								<li class="grid md:hidden bg-gray-50 rounded-lg text-center my-2 p-2">
+									<p class="text-base font-semibold text-gray-900">
+										合計 ${{ jg.total_amount | intcomma }}
+									</p>
+								</li>
+							</ul>
+							
+								<div class="flex justify-end items-center gap-2 pt-2">
+									<a href="#" class="card-btn card-btn-white">修改跟團</a>
+									<form action="#" method="post" class="inline">
+										{% csrf_token %}
+										<input type="hidden" name="_method" value="delete" />
+										<input type="hidden" name="group-id" value="{{ jg.group.id }}" />
+										<button type="submit" class="card-btn card-btn-red">退團</button>
+									</form>
+								</div>
+							</div>
+					</div>
+				</div>
 			</div>
-		</section>
+			{% endfor %}
+		
+	</section>
 	{% endif %}
-
+	
 	{# 訂單紀錄：orders #}
 	{% if orders %}
-		<section>
-			<h2 class="text-center text-lg font-medium text-gray-800 mb-4">訂單紀錄</h2>
-			<div class="overflow-x-auto bg-transparent rounded-2xl border border-gray-300">
-				<table class="min-w-full border-collapse table-fixed text-sm" style="border-spacing:0">
-					<colgroup>
-						<col style="width:340px;" /> <!-- 團購/訂單(含圖) -->
-						<col style="width:373px;" /> <!-- 商品 -->
-						<col style="width:97px;" /> <!-- 價格 -->
-						<col style="width:65px;" /> <!-- 數量 -->
-						<col style="width:97px;" /> <!-- 小計 -->
-						<col style="width:97px;" /> <!-- 合計 -->
-						<col style="width:97px;" /> <!-- 狀態 -->
-						<col style="width:113px;" /> <!-- 操作 -->
-					</colgroup>
-					<thead class="bg-transparent">
-						<tr>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[340px]">團購 / 訂單</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[373px]">商品</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">價格</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[65px]">數量</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">小計</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">合計</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[97px]">狀態</th>
-							<th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider w-[113px]">操作</th>
-						</tr>
-					</thead>
-					<tbody class="bg-transparent">
-							{% for order in orders %}
-							<tr class="border-t border-gray-300 hover:bg-transparent transition">
-								<td class="px-4 py-8 align-top text-sm font-medium text-gray-900 w-[340px]">
-									<div class="flex items-center gap-3"> <!-- 團名與圖片水平對齊 -->
-										<div class="w-12 h-12 bg-transparent overflow-hidden rounded border border-gray-300 flex-shrink-0">
-											{% if order.group.banner %}
-												<img src="{{ order.group.banner.url }}" alt="{{ order.group.name }}" class="w-full h-full object-cover object-center block">
-											{% else %}
-												<div class="w-full h-full bg-transparent"></div>
-											{% endif %}
-										</div>
-										<div>
-											<div class="text-xs text-gray-500">#{{ order.order_number }}</div>
-											<div class="text-base font-semibold text-gray-900 mt-1 truncate">{{ order.group.name }}</div>
-										</div>
-									</div>
-								</td>
-
-								{% include 'orders/my_orders/list_columns.html' with items=order.joined_group.joined_group_products.all %}
-
-								<td class="px-4 py-8 align-top text-left text-lg font-semibold text-gray-900 w-[97px]">{% if order.formatted_amount %}${{ order.formatted_amount }}{% endif %}</td>
-
-								<td class="px-4 py-8 align-top text-left text-sm {% if order.order_status == order.OrderStatus.PENDING or order.order_status == order.OrderStatus.SHIPPED %}text-yellow-700{% else %}text-gray-700{% endif %} w-[97px]">
-									{{ order.get_order_status_display }}
-								</td>
-
-								<td class="px-4 py-8 align-top text-left w-[113px]">
-									<div class="flex flex-row flex-wrap items-start justify-start gap-2">
-										<a href="#" class="px-2 py-1 rounded-full border border-gray-300 text-sm text-gray-800 whitespace-nowrap">檢視</a>
-										{% if order.order_status == order.OrderStatus.PENDING %}
-											<form action="{% url 'orders:payment_request' order.id %}" method="post" class="inline">
-												{% csrf_token %}
-												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">去付款</button>
-											</form>
-										{% endif %}
-										{% if order.order_status == order.OrderStatus.SHIPPED %}
-											<form action="{% url 'orders:received' order.id %}" method="post" class="inline">
-												{% csrf_token %}
-												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">我收到貨了</button>
-											</form>
-										{% endif %}
-									</div>
-								</td>
-							</tr>
-						{% endfor %}
-					</tbody>
-				</table>
+	<section class="max-w-[1440px] mx-auto md:px-16 sm:px-24 mt-12 lg:mt-16">
+		<h2 class="text-center text-lg font-medium text-gray-800 mb-4">訂單紀錄</h2>
+		{% for order in orders %}
+		<div class="bg-white rounded-2xl border border-gray-300 p-6 mb-4 shadow-sm hover:shadow-md transition-shadow">
+			<!-- 訂單號碼 -->
+			<div class="flex justify-between items-center">
+				<div class="text-sm text-gray-500 mb-2">訂單號碼：#{{ order.order_number }}</div>
 			</div>
-		</section>
+			<div class="flex flex-col md:flex-row gap-6">
+				<!-- 圖片區域 -->
+				<div class="flex-shrink-0">
+					<div class="w-full h-48 lg:h-64 lg:w-64 rounded-lg border border-gray-200 overflow-hidden">
+						{% if order.group.banner %}
+						<img class="w-full h-full object-cover object-center" src="{{ order.group.banner.url }}" alt="{{ order.group.name }}">
+						{% else %}
+						<div class="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400">
+							<span>無圖片</span>
+						</div>
+						{% endif %}
+					</div>
+				</div>
+				
+				<!-- 內容區域 -->
+				<div class="flex-1 flex flex-col gap-4">
+					<div class="flex-col sm:flex-row  flex justify-between items-start sm:items-center">
+						<h2 class=" text-lg sm:text-2xl text-center md:text-left font-semibold text-gray-900">{{ order.group.name }}</h2>
+						<p class="text-sm text-right mb-2 text-gray-700">
+							已成團
+						</p>
+					</div>
+					
+					<div class="space-y-3" >
+						<ul class="min-h-[130px]">
+							<li class="grid grid-cols-1 md:grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center p-2">
+								<p class="text-sm text-gray-600">商品</p>
+								<p class="hidden md:grid grid-cols-3 gap-4 text-sm text-gray-600">
+									<span>價格</span>
+									<span>數量</span>
+									<span>小計</span>
+								</p>
+							</li>
+							{% include 'orders/my_orders/list_columns.html' with items=order.joined_group.joined_group_products.all %}
+							<li class="hidden md:grid grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+								<p class="grid col-start-2 grid-cols-3 gap-4 text-base font-semibold text-gray-900">
+									<span class="col-start-2">合計</span>
+									<span>
+										${{ order.total_amount | intcomma }}
+									</span>
+								</p>
+							</li>
+							<li class="grid md:hidden bg-gray-50 rounded-lg text-center my-2 p-2">
+								<p class="text-base font-semibold text-gray-900">
+									合計 ${{ order.total_amount | intcomma }}
+								</p>
+							</li>
+						</ul>
+						
+						<div class="flex justify-end items-center gap-2 pt-2">
+							<div class="flex items-center gap-2">
+								{% if order.order_status == order.OrderStatus.PENDING %}
+								<form action="{% url 'orders:payment_request' order.id %}" method="post" class="inline">
+									{% csrf_token %}
+									<button class="w-[80px] flex items-center justify-center px-2 py-2 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">去付款</button>
+								</form>
+								{% endif %}
+								{% if order.order_status == order.OrderStatus.SHIPPED %}
+								<form action="{% url 'orders:received' order.id %}" method="post" class="inline">
+									{% csrf_token %}
+									<button class="card-btn card-btn-secondary">我收到貨了</button>
+								</form>
+								{% endif %}
+								<a href="#" class="card-btn card-btn-white">檢視</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		{% endfor %}
+	</section>
 	{% endif %}
-{% else %}
+	{% else %}
 	<section class="mb-10">
 		<h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未有此分類訂單</h2>
 	</section>
-{% endif %}
+	{% endif %}
 </div>

--- a/orders/templates/orders/my_orders/list_columns.html
+++ b/orders/templates/orders/my_orders/list_columns.html
@@ -1,35 +1,20 @@
 {% load humanize %}
 {# Partial moved: renders 商品 / 價格 / 數量 / 小計 columns for a given `items` iterable #}
-<td class="px-4 py-8 align-top w-[373px] min-w-0">
-    <ul class="list-none space-y-8">
-        {% for jgp in items %}
-            <li class="flex items-center gap-3 min-w-0">
-                <div class="text-sm text-gray-700 truncate">{{ jgp.product.name }}</div>
-            </li>
-        {% endfor %}
-    </ul>
-</td>
+{% for jqp in items %}
+<li class="hidden md:grid grid-cols-1 md:grid-cols-2 gap-2 bg-gray-50 rounded-lg my-2 p-2">
+    <p class="text-sm text-gray-600 text-left md:text-center">{{ jqp.product.name }}</p>
+    <p class="grid grid-cols-3 gap-4 text-sm text-gray-600">
+        <span class="text-left md:text-center">${{ jqp.product.price }}</span>
+        <span class="text-left md:text-center">x {{ jqp.quantity }}</span>
+        <span class="text-center">${{ jqp.subtotal }}</span>
+    </p>
+</li>
+<li class="grid md:hidden grid-cols-4 gap-2 bg-gray-50 rounded-lg my-2 p-2">
+    <p class="text-sm col-span-3 sm:col-span-2 text-gray-600 text-left md:text-center">{{ jqp.product.name }}</p>
+    <p class="text-center col-span-1 text-right sm:text-center">x {{ jqp.quantity }}</p>
+    <p class="text-center font-bold hidden sm:grid">${{ jqp.subtotal }}</p>
+    <p class="text-sm tertiary-color-500">${{ jqp.product.price }}</p>
+    <p class="text-right font-bold col-span-3 grid sm:hidden">${{ jqp.subtotal }}</p>
+</li>
 
-<td class="px-4 py-8 align-top text-left text-sm text-gray-700 w-[97px]">
-    <ul class="list-none flex flex-col items-start text-left space-y-8">
-        {% for jgp in items %}
-            <li class="text-sm text-gray-700">{{ jgp.product.formatted_price }}</li>
-        {% endfor %}
-    </ul>
-</td>
-
-<td class="px-4 py-8 align-top text-left text-sm text-gray-700 w-[65px]">
-    <ul class="list-none space-y-8">
-        {% for jgp in items %}
-            <li class="text-sm text-gray-700">{{ jgp.quantity }}</li>
-        {% endfor %}
-    </ul>
-</td>
-
-<td class="px-4 py-8 align-top text-left text-sm font-medium text-gray-900 w-[97px]">
-    <ul class="list-none flex flex-col items-start text-left space-y-8">
-        {% for jgp in items %}
-            <li class="text-sm text-gray-900">${{ jgp.subtotal|intcomma }}</li>
-        {% endfor %}
-    </ul>
-</td>
+{% endfor %}

--- a/orders/templates/orders/owned_orders/buyers_list.html
+++ b/orders/templates/orders/owned_orders/buyers_list.html
@@ -1,0 +1,87 @@
+{% extends "layouts/default.html"%}
+{% load humanize %}
+{% block content %}
+
+<section class="max-w-[1440px] mx-auto px-16 sm:px-24 mt-12 lg:mt-16">
+  <h2 class="text-center">{{ group.name }} - 跟團者列表</h2>
+  {% if orders %}
+  {% for order in orders %}
+  <div class="box-border flex flex-col gap-2"> 
+    <div class="mt-5">
+      <div class="flex justify-between items-center mb-2">
+        <p>訂單號碼: 
+          {% if order.order_number %}
+          {{ order.order_number }}
+          {% else %}
+          尚未產生訂單
+          {% endif %}
+        </p>
+        {% if order.order_status == "pending" %}
+        <a href="#" class="px-5 rounded-full border text-sm text-gray-800 whitespace-nowrap bg-gray-900 text-white">出貨</a>
+        {% endif %}
+      </div>
+      <div class="grid grid-cols-3 text-center border">
+        <p>品項</p>
+        <p class="border-x">數量</p>
+        <p>單價</p>
+      </div>
+      {% for jqp in order.joined_group.joined_group_products.all %}
+      <div class="grid grid-cols-3 text-center border-x">
+        <p class="border-b">{{ jqp.product.name }}</p>
+        <p class="border-x border-b">{{ jqp.quantity }}</p>
+        <p class="border-b">${{ jqp.product.price }}</p>
+      </div>
+      {% endfor %}
+      <div class="grid grid-cols-3 border-x">
+        <p class="col-span-2 text-right border-r">合計：</p>
+        <p class="text-center">${{ order.total_amount | intcomma }}</p>
+      </div>
+      <div class="border">
+        <p>收件人: {{ order.ship_recipient_name }}</p>
+        <p>電話: {{ order.ship_phone }}</p>
+        <p>付款狀態: {{ order.get_order_status_display }}</p>
+        <p>寄件地址: {{ order.ship_postal_code }} {{ order.ship_county }} {{ order.ship_district }} {{ order.ship_road }} {{ order.ship_detail }}</p>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  {% elif buyers %}
+  {% for buyer in buyers %}
+  <div class="box-border flex flex-col gap-2"> 
+    <div class="mt-5">
+      <div class="flex justify-between items-center mb-2">
+        <p>用戶ID: 
+          {% if buyer.buyer.username %}
+          {{ buyer.buyer.username }}
+          {% else %}
+          尚未產生訂單
+          {% endif %}
+        </p>
+      </div>
+      <div class="grid grid-cols-3 text-center border">
+        <p>品項</p>
+        <p class="border-x">數量</p>
+        <p>單價</p>
+      </div>
+      {% for jqp in buyer.joined_group_products.all %}
+      <div class="grid grid-cols-3 text-center border-x">
+        <p class="border-b">{{ jqp.product.name }}</p>
+        <p class="border-x border-b">{{ jqp.quantity }}</p>
+        <p class="border-b">${{ jqp.product.price }}</p>
+      </div>
+      {% endfor %}
+      <div class="grid grid-cols-3 border-x border-b">
+        <p class="col-span-2 text-right border-r">合計：</p>
+        <p class="text-center">${{ buyer.total_amount | intcomma }}</p>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  {% endif %}
+</section>
+
+
+{% endblock %}
+
+
+

--- a/orders/templates/orders/owned_orders/list.html
+++ b/orders/templates/orders/owned_orders/list.html
@@ -1,0 +1,219 @@
+{% load humanize %}
+<div class="mx-auto px-10 py-12">
+  {% if ongoing_groups or completed_groups%}
+  {% comment %} 已成團 {% endcomment %}
+  {% if completed_groups %}
+  <section class="max-w-[1440px] mx-auto md:px-16 sm:px-24 mt-12 lg:mt-16">
+    <h2 class="text-center text-lg font-medium text-gray-800 mb-4">已成團</h2>
+    {% comment %} =========== {% endcomment %}
+    {% for g in completed_groups %}
+    <div class="bg-white rounded-2xl border border-gray-300 p-6 mb-4 shadow-sm hover:shadow-md transition-shadow">
+      <div class="flex flex-col lg:flex-row gap-6">
+        {% comment %} 圖片區 {% endcomment %}
+        <div class="flex-shrink-0">
+          <div class="w-full h-48 lg:h-64 lg:w-64 rounded-lg border border-gray-200 overflow-hidden">
+            {% if g.banner.url %}
+            <img class="w-full h-full object-cover object-center" src="{{ g.banner.url }}" alt="{{ g.name }}">
+            {% else %}
+            <div class="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400">
+              <span>無圖片</span>
+            </div>
+            {% endif %}
+          </div>
+        </div>
+        {% comment %} 內容區 {% endcomment %}
+        <div class="flex-1 flex flex-col gap-4">
+          <div class="flex-col sm:flex-row  flex justify-between items-start sm:items-center">
+            <h2 class="text-lg sm:text-2xl text-center md:text-left font-semibold text-gray-900">{{ g.name }}</h2>
+            <p class="text-sm text-right text-gray-900 mb-2">已成團</p>
+          </div>
+          <div class="space-y-3" >
+            <ul class="min-h-[130px]">
+              <li class="grid grid-cols-4 gap-2 bg-gray-50 rounded-lg text-center p-2">
+                <p class="text-sm text-gray-600 col-span-3">商品</p>
+                <p class="text-sm text-gray-600">價格</p>
+              </li>
+              {% include 'orders/owned_orders/list_columns.html' with items=g.products.all %}
+              <li class="grid grid-cols-4 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+                <p class="col-span-3 text-base font-semibold text-gray-900">達標數目</p>
+                <p class="text-base font-semibold text-gray-900">
+                  {% if g.goal_choice == "quantity" %}
+                  {{ g.min_goal }}
+                  {% else %}
+                  {{ g.min_goal | intcomma }}
+                  {% endif %}
+                </p>
+              </li>
+            </ul>
+            <div class="flex lg:flex-row flex-col justify-between items-center gap-2 ">
+              <div>
+                <p class="text-base text-red-500">
+                  截止日期：{{ g.deadline|date:"Y-m-d" }}
+                </p>
+              </div>
+              <div class="flex items-center gap-2">
+                <a href="{% url 'groups:manage' g.id %}" class="card-btn card-btn-white">團購頁面</a>
+                <a href="{% url 'orders:buyer_list' g.id %} " class="card-btn card-btn-secondary">檢視跟團者</a>
+              </div>
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    {% endfor %}
+  </section>
+  {% else %}
+  <section class="mb-20 pb-20 border-b border-gray-300">
+    <h2 class="text-center text-lg text-red-500 font-medium text-gray-800 mb-4">已成團</h2>
+    <p class="text-center text-gray-300 mb-4">還沒有任何成團的團購</p>
+  </section>
+  {% endif %}
+  
+  {% comment %} 未成團 {% endcomment %}
+  {% if ongoing_groups %}
+  <section class="max-w-[1440px] mx-auto md:px-16 sm:px-24 mt-12 lg:mt-16">
+    <h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未成團</h2>
+    {% for g in ongoing_groups %}
+    <div class="bg-white rounded-2xl border border-gray-300 p-6 mb-4 shadow-sm hover:shadow-md transition-shadow">
+      <div class="flex flex-col lg:flex-row gap-6">
+        {% comment %} 圖片區 {% endcomment %}
+        <div class="flex-shrink-0">
+          <div class="w-full h-48 lg:h-64 lg:w-64 rounded-lg border border-gray-200 overflow-hidden">
+            {% if g.banner.url %}
+            <img class="w-full h-full object-cover object-center" src="{{ g.banner.url }}" alt="{{ g.name }}">
+            {% else %}
+            <div class="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400">
+              <span>無圖片</span>
+            </div>
+            {% endif %}
+          </div>
+        </div>
+        {% comment %} 內容區 {% endcomment %}
+        <div class="flex-1 flex flex-col gap-4">
+          <div class="flex-col sm:flex-row  flex justify-between items-start sm:items-center">
+            <h2 class="text-lg sm:text-2xl text-center md:text-left font-semibold text-gray-900">{{ g.name }}</h2>
+            <p class="text-sm text-right text-red-500 mb-2">未成團</p>
+          </div>
+          <div class="space-y-3" >
+            <ul class="min-h-[130px]">
+              <li class="grid grid-cols-4 gap-2 bg-gray-50 rounded-lg text-center p-2">
+                <p class="text-sm text-gray-600 col-span-3">商品</p>
+                <p class="text-sm text-gray-600">價格</p>
+              </li>
+              {% include 'orders/owned_orders/list_columns.html' with items=g.products.all %}
+              <li class="grid grid-cols-4 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+                <p class="col-span-3 text-base font-semibold text-gray-900">達標數目</p>
+                <p class="text-base font-semibold text-gray-900">
+                  {% if g.goal_choice == "quantity" %}
+                  {{ g.min_goal }}
+                  {% else %}
+                  {{ g.min_goal | intcomma }}
+                  {% endif %}
+                </p>
+              </li>
+            </ul>
+            <div class="flex lg:flex-row flex-col justify-between items-center gap-2 ">
+              <div>
+                <p class="text-base text-red-500">
+                  截止日期：{{ g.deadline|date:"Y-m-d" }}
+                </p>
+              </div>
+              <div class="flex items-center gap-2">
+                <a href="{% url 'groups:manage' g.id %}" class="card-btn card-btn-white">團購頁面</a>
+                <a href="{% url 'orders:buyer_list' g.id %}" class="card-btn card-btn-secondary">檢視跟團者</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+    </div>
+    {% endfor %}
+    {% else %}
+    <section class="mb-20 pb-20 border-b border-gray-300">
+      <h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未成團</h2>
+      <p class="text-center text-gray-300 mb-4">沒有任何尚未成團的團購</p>
+    </section>
+    {% endif %}
+  </section>
+  {% comment %} 訂單紀錄 {% endcomment %}
+  {% elif orders %}
+	<section class="max-w-[1440px] mx-auto md:px-16 sm:px-24 mt-12 lg:mt-16">
+		<h2 class="text-center text-lg font-medium text-gray-800 mb-4">訂單紀錄</h2>
+		{% for order in orders %}
+		<div class="bg-white rounded-2xl border border-gray-300 p-6 mb-4 shadow-sm hover:shadow-md transition-shadow">
+			<!-- 訂單號碼 -->
+			<div class="flex justify-between items-center">
+				<div class="text-sm text-gray-500 mb-2">訂單號碼：#{{ order.order_number }}</div>
+			</div>
+			<div class="flex flex-col md:flex-row gap-6">
+				<!-- 圖片區域 -->
+				<div class="flex-shrink-0">
+					<div class="w-full h-48 lg:h-64 lg:w-64 rounded-lg border border-gray-200 overflow-hidden">
+						{% if order.group.banner %}
+						<img class="w-full h-full object-cover object-center" src="{{ order.group.banner.url }}" alt="{{ order.group.name }}">
+						{% else %}
+						<div class="w-full h-full bg-gray-100 flex items-center justify-center text-gray-400">
+							<span>無圖片</span>
+						</div>
+						{% endif %}
+					</div>
+				</div>
+				
+				<!-- 內容區域 -->
+				<div class="flex-1 flex flex-col gap-4">
+					<div class="flex-col sm:flex-row  flex justify-between items-start sm:items-center">
+						<h2 class=" text-lg sm:text-2xl text-center md:text-left font-semibold text-gray-900">{{ order.group.name }}</h2>
+						<p class="text-sm text-right mb-2 {% if order.order_status == order.OrderStatus.PROCESSING %}text-red-500{% else %}text-gray-700{% endif %}">
+							{{ order.get_order_status_display }}
+						</p>
+					</div>
+					
+
+					<div class="space-y-3" >
+						<ul class="min-h-[130px]">
+							<li class="grid grid-cols-1 md:grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center p-2">
+								<p class="text-sm text-gray-600">商品</p>
+								<p class="hidden md:grid grid-cols-3 gap-4 text-sm text-gray-600">
+									<span>價格</span>
+									<span>數量</span>
+									<span>小計</span>
+								</p>
+							</li>
+							{% include 'orders/my_orders/list_columns.html' with items=order.joined_group.joined_group_products.all %}
+							<li class="hidden md:grid grid-cols-2 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+								<p class="grid col-start-2 grid-cols-3 gap-4 text-base font-semibold text-gray-900">
+									<span class="col-start-2">合計</span>
+									<span>
+										${{ order.total_amount | intcomma }}
+									</span>
+								</p>
+							</li>
+							<li class="grid md:hidden bg-gray-50 rounded-lg text-center my-2 p-2">
+								<p class="text-base font-semibold text-gray-900">
+									合計 ${{ order.total_amount | intcomma }}
+								</p>
+							</li>
+						</ul>
+						
+						<div class="flex justify-end items-center gap-2 pt-2">
+							<div class="flex items-center gap-2">
+								{% if order.order_status == order.OrderStatus.PROCESSING %}
+								<a class="card-btn card-btn-secondary">去出貨</a>
+								{% endif %}
+								<a href="{% url 'groups:manage' order.group.id %}" class="card-btn card-btn-white">檢視</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		{% endfor %}
+	</section>
+	{% else %}
+	<section class="mb-10">
+		<h2 class="text-center text-lg font-medium text-gray-800 mb-4">尚未有此分類訂單</h2>
+	</section>
+	{% endif %}

--- a/orders/templates/orders/owned_orders/list_columns.html
+++ b/orders/templates/orders/owned_orders/list_columns.html
@@ -1,0 +1,8 @@
+{% load humanize %}
+
+{% for p in items %}
+<li class="grid grid-cols-4 gap-2 bg-gray-50 rounded-lg text-center my-2 p-2">
+    <p class="text-sm text-gray-600 col-span-3">{{ p.name }}</p>
+    <p class="text-sm text-gray-600">{{ p.formatted_price }}</p>
+</li>
+{% endfor %}

--- a/orders/templates/orders/owned_orders/navbar.html
+++ b/orders/templates/orders/owned_orders/navbar.html
@@ -1,0 +1,52 @@
+<nav aria-label="我的訂單分頁" class="my-6">
+  <ul class="mx-auto flex flex-wrap justify-center gap-4 bg-transparent rounded-md px-2 py-1">
+      <li>
+              <a hx-get="{% url 'orders:owned_orders_tab_content' %}?tab=all"
+                  hx-target="#my-order-list"
+                  hx-swap="innerHTML"
+                  hx-trigger="click"
+                  class="cursor-pointer inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 rounded-md border-b-2 border-transparent opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-200">
+              全部訂單
+          </a>
+      </li>
+      <li>
+          <a hx-get="{% url 'orders:owned_orders_tab_content' %}?tab=pending"
+             hx-target="#my-order-list"
+             hx-swap="innerHTML"
+             hx-trigger="click"
+             class="cursor-pointer inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 rounded-md border-b-2 border-transparent opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-200">
+              待付款訂單
+          </a>
+      </li>
+
+      <li>
+          <a hx-get="{% url 'orders:owned_orders_tab_content' %}?tab=processing"
+             hx-target="#my-order-list"
+             hx-swap="innerHTML"
+             hx-trigger="click"
+             class="cursor-pointer inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 rounded-md border-b-2 border-transparent opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-200">
+              待出貨訂單
+          </a>
+      </li>
+
+      <li>
+          <a hx-get="{% url 'orders:owned_orders_tab_content' %}?tab=shipped"
+             hx-target="#my-order-list"
+             hx-swap="innerHTML"
+             hx-trigger="click"
+             class="cursor-pointer inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 rounded-md border-b-2 border-transparent opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-200">
+              已出貨訂單
+          </a>
+      </li>
+
+      <li>
+          <a hx-get="{% url 'orders:owned_orders_tab_content' %}?tab=completed"
+             hx-target="#my-order-list"
+             hx-swap="innerHTML"
+             hx-trigger="click"
+             class="cursor-pointer inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 rounded-md border-b-2 border-transparent opacity-70 hover:opacity-100 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-200">
+              已完成訂單
+          </a>
+      </li>
+  </ul>
+</nav>

--- a/orders/templates/orders/owned_orders/section.html
+++ b/orders/templates/orders/owned_orders/section.html
@@ -1,0 +1,11 @@
+{% extends "layouts/default.html"%}
+{% block content %}
+
+{% include "orders/shared/navbar.html" %}
+{% include 'orders/owned_orders/navbar.html' %}
+
+<div id="my-order-list">
+    {% include 'orders/owned_orders/list.html' %}
+</div>
+
+{% endblock %}

--- a/orders/templates/orders/shared/navbar.html
+++ b/orders/templates/orders/shared/navbar.html
@@ -5,8 +5,7 @@
                class="inline-flex items-center px-6 py-2 rounded-full text-base font-medium text-white bg-black cursor-pointer opacity-100">
                 我跟團的訂單
             </a>
-
-            <a href="#"
+            <a href="{% url 'orders:owned_orders' %}"
                class="inline-flex items-center px-6 py-2 rounded-full text-base font-medium text-gray-800 cursor-pointer opacity-70 hover:opacity-100 transition-opacity">
                 我開團的訂單
             </a>

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -12,6 +12,17 @@ urlpatterns = [
         views.my_orders_tab_content,
         name="my_orders_tab_content",
     ),
+    # ========== 我開團的訂單相關 ==========
+    # 全部我的開團訂單
+    path("owned-orders/", views.owned_orders, name="owned_orders"),
+    path(
+        "owned-orders/tab-content/",
+        views.owned_orders_tab_content,
+        name="owned_orders_tab_content",
+    ),
+    # 跟團者列表
+    path("owned-orders/buyer_list/<int:group_id>/", views.buyer_list, name="buyer_list"),
+    
     # 確認收貨
     path("my-orders/received/<int:order_id>/", views.received, name="received"),
     # ========== 付款相關 ==========

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,3 +1,4 @@
+from tokenize import group
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.http import require_POST
 from django.contrib import messages
@@ -9,9 +10,10 @@ import hashlib
 import base64
 import requests
 from .models import Order, Payment
-from groups.models import JoinedGroup
+from groups.models import JoinedGroup, Group
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse
+from django.db.models import Sum, F
 
 
 def create_headers(body, uri):
@@ -200,12 +202,12 @@ def success(request):
 def fail(request):
     return render(request, "orders/payment_fail.html")
 
-
+# 我跟團的訂單
 @login_required
 def my_orders(request):
     user = request.user
     tab = request.GET.get("tab", "all")
-    auto_tab = request.GET.get("auto_tab")
+    auto_tab = request.GET.get("auto_tab")    
 
     # 如果有 auto_tab，就用 auto_tab 作為初始內容
     display_tab = auto_tab if auto_tab else tab
@@ -248,6 +250,7 @@ def get_orders_by_tab(user, tab):
         .order_by("-updated_at")
         .select_related("group", "joined_group")
         .prefetch_related("joined_group__joined_group_products__product")
+        .annotate(total_amount=Sum(F('joined_group__joined_group_products__product__price') * F('joined_group__joined_group_products__quantity')))
     )
 
     # 找出所有跟團紀錄
@@ -256,6 +259,7 @@ def get_orders_by_tab(user, tab):
         .order_by("-updated_at")
         .select_related("group")
         .prefetch_related("joined_group_products__product")
+        .annotate(total_amount=Sum(F('joined_group_products__product__price') * F('joined_group_products__quantity')))
     )
 
     if tab == "all":
@@ -278,6 +282,133 @@ def get_orders_by_tab(user, tab):
         orders = base_orders_query.filter(order_status=Order.OrderStatus.COMPLETED)
 
     return orders, joined_groups
+
+# 我開團的訂單
+@login_required
+def owned_orders(request):
+    user = request.user
+    tab = request.GET.get("tab", "all")
+    auto_tab = request.GET.get("auto_tab")    
+
+    # 如果有 auto_tab，就用 auto_tab 作為初始內容
+    display_tab = auto_tab if auto_tab else tab
+
+    ongoing_groups, completed_groups, orders = get_data_by_tab(user, display_tab)
+
+    return render(
+        request,
+        "orders/owned_orders/section.html",
+        {
+            "ongoing_groups": ongoing_groups,
+            "completed_groups": completed_groups,
+            "orders": orders,
+            "current_tab": display_tab,
+            "auto_tab": auto_tab,
+        },
+    )
+
+@login_required
+def owned_orders_tab_content(request):
+    user = request.user
+    tab = request.GET.get("tab", "all")
+
+    ongoing_groups, completed_groups, orders = get_data_by_tab(user, tab)
+
+    return render(
+        request,
+        "orders/owned_orders/list.html",
+        {
+            "ongoing_groups": ongoing_groups,
+            "completed_groups": completed_groups,
+            "orders": orders,
+            "current_tab": tab,
+        },
+    )
+
+def get_data_by_tab(user, tab):
+    ongoing_groups = []
+    completed_groups = []
+    orders = []
+
+    base_groups_query = (
+        Group.objects.filter(owner=user)
+        .order_by("-created_at")
+        .select_related("owner")
+        .prefetch_related("products", "order_set")
+    )
+
+    base_orders_query = (
+        Order.objects.filter(group__status="completed", group__owner=user)
+        .order_by("updated_at")
+        .select_related("group", "user")
+        .prefetch_related("joined_group__joined_group_products__product")
+        .annotate(total_amount=Sum(F('joined_group__joined_group_products__product__price') * F('joined_group__joined_group_products__quantity')))
+    )
+
+    if tab == "all":
+        ongoing_groups = base_groups_query.filter(status="ongoing")
+        completed_groups = base_groups_query.filter(status="completed")
+    
+    if tab == "pending":
+        orders = base_orders_query.filter(order_status=Order.OrderStatus.PENDING)
+
+    if tab == "processing":
+        orders = base_orders_query.filter(order_status=Order.OrderStatus.PROCESSING)
+
+    if tab == "shipped":
+        orders = base_orders_query.filter(order_status=Order.OrderStatus.SHIPPED)
+
+    if tab == "completed":
+        orders = base_orders_query.filter(order_status=Order.OrderStatus.COMPLETED)
+
+
+    return ongoing_groups, completed_groups, orders
+
+# 跟團者列表
+@login_required
+def buyer_list(request, group_id):
+    group = get_object_or_404(Group, id=group_id)
+    
+    orders = []
+    buyers = []
+
+    completed_groups = (
+        Order.objects.filter(
+            group_id=group_id,
+            group__status="completed",
+        )
+        .prefetch_related(
+            "joined_group__joined_group_products__product", 
+        )
+        .annotate(total_amount=Sum(F('joined_group__joined_group_products__product__price') * F('joined_group__joined_group_products__quantity')))
+        # joined_group__joined_group_products__quantity | joined_group__joined_group_products.quantity
+        # joined_group__joined_group_products__product__price | joined_group__joined_group_products.product.price
+    )
+
+    ongoing_groups = (
+        JoinedGroup.objects.filter(
+            group_id=group_id, 
+            group__status="ongoing"
+        )
+        .select_related("buyer")
+        .prefetch_related(
+            "joined_group_products__product",
+        )
+        .annotate(total_amount=Sum(F('joined_group_products__product__price') * F('joined_group_products__quantity')))
+    )
+
+
+    if group.status == "ongoing":
+        buyers = ongoing_groups
+    
+    if group.status == "completed":
+        orders = completed_groups
+
+    return render(request, "orders/owned_orders/buyers_list.html", {
+        'group': group,
+        'orders': orders,
+        'buyers': buyers
+    })
 
 
 # 確認收貨

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -17,6 +17,8 @@
   --tertiary-color-50: #f8f8f8;
   --tertiary-color-300: #bdbdbd;
   --tertiary-color-500: #7c7c7c;
+  --red-color-500: #fb2c36;
+  --red-color-700: #c10007;
 }
 
 html {
@@ -140,6 +142,50 @@ html {
 
 .nav-btn:hover::after {
   width: 60%;
+}
+
+
+/* card-btn */
+.card-btn{
+  
+  display: flex;
+  cursor: pointer;
+  border-radius: 50px;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 10px;
+  font-size: 14px;
+}
+.card-btn-white {
+  background-color: #ffffff;
+  border: 1px solid var(--secondary-color);
+  color: var(--secondary-color);
+}
+
+.card-btn-white:hover {
+  background-color: var(--secondary-color);
+  color: #ffffff;
+}
+
+.card-btn-red{
+  border: 1px solid var(--red-color-500);
+  color: var(--red-color-500);
+}
+
+.card-btn-red:hover {
+  background-color: var(--red-color-500);
+  color: #ffffff;
+}
+
+.card-btn-secondary{
+  background-color: var(--secondary-color);
+  border: 1px solid var(--secondary-color);
+  color: #ffffff;
+}
+
+.card-btn-secondary:hover {
+  background-color: #ffffff;
+  color: var(--secondary-color);
 }
 
 /* 響應式 */


### PR DESCRIPTION
close #138 
- 使用 Grid 排版
- 畫面「小計」、「合計」顯示修復。
- 優化我跟團/開團的訂單樣式。
- 新增跟團者列表頁面。

## 二更
- 修正 `groups/forms.py`，讓 `Form` 引用 `Model` 定義的 `Group.GOAL_CHOICES`。
- 根據組員建議套上`<section class="max-w-[1440px] mx-auto px-16 sm:px-24 mt-12 lg:mt-16">`標籤，有適當修正。
- 畫面上「小計」、「合計」、「金額目標」顯示千分位逗號。


https://github.com/user-attachments/assets/35d5c99c-b0f8-433a-96c5-33acf7160a7a



