### PR TITLE
Feat#124: 付款時的選擇地址／地址新增頁面 

### DIFF
--- a/orders/apps.py
+++ b/orders/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class OrdersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'orders'
+
+    def ready(self):
+        # 在 App 啟動時 import signals
+        import orders.signals

--- a/orders/signals.py
+++ b/orders/signals.py
@@ -1,0 +1,16 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Payment
+
+
+@receiver(post_save, sender=Payment)
+def mark_others_payment_fail(sender, instance, created, **kwargs):
+    if created:
+        qs = Payment.objects.filter(
+            order_id=instance.order_id, payment_status="pending"
+        )
+
+        if instance.pk:
+            qs = qs.exclude(pk=instance.pk)
+
+        qs.update(payment_status="failed")

--- a/orders/templates/orders/check_order.html
+++ b/orders/templates/orders/check_order.html
@@ -1,0 +1,60 @@
+{% extends "layouts/default.html" %}
+{% block content %}
+<section class="max-w-[1440px] mx-auto px-16 sm:px-24 mt-12 lg:mt-16">
+    <h1 class="text-2xl font-bold mb-6">確認訂單資訊</h1>
+    
+    <div class="bg-gray-50 p-6 rounded-lg mb-6">
+        <h2 class="text-xl mb-4">訂單資訊</h2>
+        <p><strong>訂單編號:</strong> {{order.order_number}}</p>
+        <p><strong>團購名稱:</strong> {{order.group.name}}</p>
+    </div>
+
+    <div class="bg-gray-50 p-6 rounded-lg mb-6">
+        <h2 class="text-xl mb-4">收件資訊</h2>
+        <p><strong>收件人:</strong> {{order.ship_recipient_name}}</p>
+        <p><strong>電話:</strong> {{order.ship_phone}}</p>
+        <p><strong>地址:</strong> {{order.ship_postal_code}} {{order.ship_county}}{{order.ship_district}}{{order.ship_road}}{{order.ship_detail}}</p>
+    </div>
+    
+    <div class="bg-gray-50 p-6 rounded-lg mb-6">
+        <h2 class="text-xl mb-4">商品明細</h2>
+        <table class="w-full">
+            <thead>
+                <tr class="border-b">
+                    <th class="text-left p-2">商品名稱</th>
+                    <th class="text-right p-2">單價</th>
+                    <th class="text-right p-2">數量</th>
+                    <th class="text-right p-2">小計</th>
+                </tr>
+            </thead>
+            <tbody>
+                    {% for joined_group_product in joined_group_products %}
+                        <tr class="border-b">
+                            <td class="p-2">
+                                {% if joined_group_product.product.banner %}
+                                    <img src="{{ joined_group_product.product.banner.url }}" class="w-16 h-16 object-cover inline-block mr-2">
+                                {% endif %}
+                                {{ joined_group_product.product.name }}
+                            </td>
+                            <td class="text-right p-2">{{ joined_group_product.product.formatted_price }}</td>
+                            <td class="text-right p-2">{{ joined_group_product.quantity }}</td>
+                            <td class="text-right p-2">${{ joined_group_product.subtotal|floatformat:0 }}</td>
+                        </tr>
+                    {% endfor %}
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="3" class="text-right p-2 font-bold">總計:</td>
+                    <td class="text-right p-2 font-bold">${{ order.amount|floatformat:0 }}</td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    <form action="{% url 'orders:payment_request' order.id %}" method="post" class="flex justify-between">
+        {% csrf_token %}
+        <a href="{% url 'orders:ship_address' order.id %}" class="px-6 py-2 border rounded">回上一步</a>
+        <button class="px-6 py-2 bg-blue-500 text-white rounded">去付款</button>
+    </form>
+</section>
+{% endblock %}

--- a/orders/templates/orders/my_orders/list.html
+++ b/orders/templates/orders/my_orders/list.html
@@ -129,7 +129,7 @@
 									<div class="flex flex-row flex-wrap items-start justify-start gap-2">
 										<a href="#" class="px-2 py-1 rounded-full border border-gray-300 text-sm text-gray-800 whitespace-nowrap">檢視</a>
 										{% if order.order_status == order.OrderStatus.PENDING %}
-											<form action="{% url 'orders:payment_request' order.id %}" method="post" class="inline">
+											<form action="{% url 'orders:ship_address' order.id %}" method="post" class="inline">
 												{% csrf_token %}
 												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">去付款</button>
 											</form>

--- a/orders/templates/orders/my_orders/list.html
+++ b/orders/templates/orders/my_orders/list.html
@@ -128,18 +128,20 @@
 								<td class="px-4 py-8 align-top text-left w-[113px]">
 									<div class="flex flex-row flex-wrap items-start justify-start gap-2">
 										<a href="#" class="px-2 py-1 rounded-full border border-gray-300 text-sm text-gray-800 whitespace-nowrap">檢視</a>
+
 										{% if order.order_status == order.OrderStatus.PENDING %}
-											<form action="{% url 'orders:ship_address' order.id %}" method="post" class="inline">
-												{% csrf_token %}
-												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">去付款</button>
-											</form>
+												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">
+													<a href="{% url 'orders:ship_address' order.id %}">去付款</a>
+												</button>
 										{% endif %}
+
 										{% if order.order_status == order.OrderStatus.SHIPPED %}
 											<form action="{% url 'orders:received' order.id %}" method="post" class="inline">
 												{% csrf_token %}
 												<button class="px-2 py-1 rounded-full bg-gray-900 text-white text-sm font-semibold hover:opacity-90 whitespace-nowrap">我收到貨了</button>
 											</form>
 										{% endif %}
+
 									</div>
 								</td>
 							</tr>

--- a/orders/templates/orders/ship_address.html
+++ b/orders/templates/orders/ship_address.html
@@ -1,0 +1,72 @@
+{% extends "layouts/default.html" %}
+{% block content %}
+<section class="max-w-[1440px] mx-auto px-16 sm:px-24 mt-12 lg:mt-16"
+         x-data="{show_create_modal : {{show_create_modal|yesno:"true,false"|default:'false'}}}">
+    <div class="flex gap-4">
+        <p>1.選擇地址</p>
+        <p>2.確認訂單資訊</p>
+        <p>3.付款</p>
+    </div>
+       
+    <form action="{% url 'orders:check_order' order.id %}" method="post">
+        {% csrf_token %}
+            <button @click="show_create_modal = true" type="button" class="border-b-2">新增其他地址</button>
+            <button class="border-b-2">下一步</button>
+
+
+        <ul class="flex flex-col gap-4">
+            {% for address in addresses %}
+                    <li class="flex justify-between hover:bg-white">
+                    <label for="address-{{address.id}}" class="w-full cursor-pointer">
+                            <div class="flex">
+                                <p>{{address.recipient_name}}</p>
+                            </div>
+
+                            <div class="flex">
+                                <p>{{address.phone}}</p>
+                            </div>
+                        
+                            <div class="flex">
+                                <p>{{address.postal_code}} {{address.county}}{{address.district}}{{address.road}}{{address.detail}}</p>
+                            </div>
+                    </label>
+
+                    <div>
+                            {% if address.is_default %}
+                                <input type="radio" id="address-{{address.id}}" name="ship-address" value="address-{{address.id}}" class="cursor-pointer" checked />
+                            {% else %}
+                                <input type="radio" id="address-{{address.id}}" name="ship-address" value="address-{{address.id}}" class="cursor-pointer"/>
+                            {% endif %}
+                    </div>
+                    
+                    </li>
+                
+        {% endfor %}
+        </ul>
+    </form>
+
+    <!-- 新增收貨地址彈窗-->
+    <div x-show="show_create_modal" x-cloak>
+        <div action="#"
+              x-data="addressFormControl"
+              class="fixed inset-0 bg-black/60 flex items-center justify-center z-100 text-center"
+              >
+            <form action="{% url 'orders:check_order' order.id %}" method="post" class="bg-[var(--bg-color)] p-20 rounded-2xl" novalidate>
+                 <input type="hidden" name="create_new_address" value="1">
+
+                {% csrf_token %}
+                {% include "users/shared/address_form_fields.html" %}
+
+                <div class="flex gap-4">
+                    <button>下一步</button>
+                    <button type="button" @click="show_create_modal=false; window.location.href='{% url 'orders:ship_address' order.id %}?clear_modal=1'">取消</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+
+
+
+
+{% endblock %}

--- a/orders/templates/orders/ship_address.html
+++ b/orders/templates/orders/ship_address.html
@@ -47,8 +47,7 @@
 
     <!-- 新增收貨地址彈窗-->
     <div x-show="show_create_modal" x-cloak>
-        <div action="#"
-              x-data="addressFormControl"
+        <div x-data="addressFormControl"
               class="fixed inset-0 bg-black/60 flex items-center justify-center z-100 text-center"
               >
             <form action="{% url 'orders:check_order' order.id %}" method="post" class="bg-[var(--bg-color)] p-20 rounded-2xl" novalidate>

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -13,11 +13,24 @@ urlpatterns = [
         name="my_orders_tab_content",
     ),
     # 確認收貨
-    path("my-orders/received/<int:order_id>/", views.received, name="received"),
+    path("my-orders/<int:order_id>/received/", views.received, name="received"),
+    # ========== 選擇收貨地址相關 ==========
+    # 選擇地址
+    path(
+        "my-orders/<int:order_id>/ship_address/",
+        views.ship_address,
+        name="ship_address",
+    ),
     # ========== 付款相關 ==========
+    # 確認訂單資訊
+    path(
+        "my-orders/<int:order_id>/check_order/",
+        views.check_order,
+        name="check_order",
+    ),
     # 請求付款
     path(
-        "my-orders/payment/request/<int:order_id>/",
+        "my-orders/<int:order_id>/payment/request/",
         views.request,
         name="payment_request",
     ),

--- a/orders/views.py
+++ b/orders/views.py
@@ -9,6 +9,7 @@ import hashlib
 import base64
 import requests
 from users.models import UserAddress
+from users.forms import UserAddressForm
 from .models import Order, Payment
 from groups.models import JoinedGroup
 from django.contrib.auth.decorators import login_required
@@ -25,22 +26,106 @@ REQUIRED_ADDR_FIELDS = (
 )
 
 
-# TODO
 @login_required
-def go_to_payment(request, order_id):
-    order = get_object_or_404(Order, pk=order_id, user=request.user)
-    address_id = request.POST.get("address_id")
-    addr = get_object_or_404(UserAddress, pk=address_id, user=request.user)
+def ship_address(request, order_id):
+    addresses = UserAddress.objects.filter(user=request.user).order_by("-is_default")
+    default_address = addresses.filter(is_default=True).first()
+
+    # 如果預設地址裡有 None，跳轉到個人頁面請他修改
+    default_is_complete = (
+        any(getattr(default_address, field)) in (None, "")
+        for field in REQUIRED_ADDR_FIELDS
+    )
+
+    if not default_is_complete:
+        messages.warning(request, "請先更新預設地址，再至訂單結帳")
+        return redirect("users:profile")
+
+    order = get_object_or_404(Order, pk=order_id)
+    blank_address_form = UserAddressForm()
+
+    # 如果是取消按鈕被點擊
+    if request.GET.get("clear_modal") == '1':
+        request.session["show_create_modal"] = False
+        request.session.modified = True
+        return redirect("orders:ship_address", order_id=order_id)
+
+    # 直接設定或獲取彈窗狀態，預設為 False
+    show_create_modal = request.session.get("show_create_modal", False)
+
+    return render(
+        request,
+        "orders/ship_address.html",
+        {
+            "addresses": addresses,
+            "order": order,
+            "user_address_form": blank_address_form,
+            "show_create_modal": show_create_modal,
+        },
+    )
+
+
+@login_required
+def check_order(request, order_id):
+    user = request.user
+    order = get_object_or_404(Order, pk=order_id, user=user)
+
+    # 代表使用剛剛新增的地址
+    if request.POST.get("create_new_address") == "1":
+        new_address_form = UserAddressForm(request.POST)
+        if new_address_form.is_valid():
+            address = new_address_form.save(commit=False)
+            address.user = user
+            address.save()
+            # 刪除 session 的 show_create_modal 狀態
+            if "show_create_modal" in request.session:
+                del request.session["show_create_modal"]
+        else:
+            # 新增地址欄位出錯，將彈窗顯示
+            request.session["show_create_modal"] = True
+            addresses = UserAddress.objects.filter(user=request.user).order_by(
+                "-is_default"
+            )
+            return render(
+                request,
+                "orders/ship_address.html",
+                {
+                    "addresses": addresses,
+                    "order": order,
+                    "user_address_form": new_address_form,
+                    "show_create_modal": request.session["show_create_modal"],
+                },
+            )
+
+    else:
+        address_id = request.POST.get("ship-address").replace("address-", "")
+        address = get_object_or_404(UserAddress, pk=address_id, user=user)
 
     # 檢查這筆地址是否完整
-    missing = [f for f in REQUIRED_ADDR_FIELDS if not getattr(addr, f)]
+    missing = [field for field in REQUIRED_ADDR_FIELDS if not getattr(address, field)]
     if missing:
         messages.error(request, "這個地址資料不完整，請先進行編輯")
         return redirect("users:profile")
 
-    # 存地址快照，建立 payment
-    order.apply_address(addr)
-    return redirect("orders:request", order.id)
+    # 存地址快照
+    order.apply_address(address)
+
+    joined_group = (
+        JoinedGroup.objects.filter(order=order)
+        .prefetch_related("joined_group_products__product")
+        .first()
+    )
+    joined_group_products = joined_group.joined_group_products.all()
+
+    return render(
+        request,
+        "orders/check_order.html",
+        {
+            "order": order,
+            "joined_group": joined_group,
+            "joined_group_products": joined_group_products,
+        },
+    )
 
 
 def create_headers(body, uri):
@@ -69,10 +154,8 @@ def create_headers(body, uri):
 @require_POST
 @login_required
 def request(request, order_id):
-    user = request.user
     order = get_object_or_404(Order, pk=order_id)
-
-    if not order.user == user:
+    if not order.user == request.user:
         messages.error(request, "訂單發生錯誤，請稍後再試")
         return redirect(f"{reverse('orders:my_orders')}?auto_tab=pending")
 
@@ -81,7 +164,6 @@ def request(request, order_id):
         return redirect(f"{reverse('orders:my_orders')}?auto_tab=processing")
 
     payment = Payment.objects.create(order=order)
-
     package_id = f"pkg_{order.order_number}_{str(uuid.uuid4())[:8]}"
 
     payload = {

--- a/orders/views.py
+++ b/orders/views.py
@@ -32,14 +32,13 @@ def ship_address(request, order_id):
     default_address = addresses.filter(is_default=True).first()
 
     # 如果預設地址裡有 None，跳轉到個人頁面請他修改
-    default_is_complete = (
-        any(getattr(default_address, field)) in (None, "")
-        for field in REQUIRED_ADDR_FIELDS
+    default_is_not_complete = any(
+        getattr(default_address, field) in (None, "") for field in REQUIRED_ADDR_FIELDS
     )
 
-    if not default_is_complete:
+    if default_is_not_complete:
         messages.warning(request, "請先更新預設地址，再至訂單結帳")
-        return redirect("users:profile")
+        return redirect("users:profiles")
 
     order = get_object_or_404(Order, pk=order_id)
     blank_address_form = UserAddressForm()
@@ -98,7 +97,12 @@ def check_order(request, order_id):
             )
 
     else:
-        address_id = request.POST.get("ship-address").replace("address-", "")
+        ship_address_val = request.POST.get("ship-address")
+        if not ship_address_val:
+            messages.error(request, "請選擇一個收貨地址。")
+            return redirect("orders:ship_address", order_id=order_id)
+
+        address_id = ship_address_val.replace("address-", "")
         address = get_object_or_404(UserAddress, pk=address_id, user=user)
 
     # 檢查這筆地址是否完整

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -27,6 +27,10 @@ html {
   list-style-type: none;
 }
 
+button {
+  cursor: pointer;
+}
+
 .primary-color {
   color: var(--primary-color);
 }

--- a/users/templates/users/shared/address_form_fields.html
+++ b/users/templates/users/shared/address_form_fields.html
@@ -17,7 +17,7 @@
 
 
 <!-- 是否預設 -->
-<div class="flex justify-between items-center gap-3 mt-4">
+ <div class="flex justify-between items-center gap-3 mt-4">
     <label for="{{ user_address_form.is_default.id_for_label }}" class="font-semibold">
         {{ user_address_form.is_default.label }}
     </label>
@@ -27,7 +27,7 @@
     <div class="red-color-700 text-sm mt-2">
         {{ user_address_form.is_default.errors.0 }}
     </div>
-{% endif %}
+{% endif %} 
 
 
 


### PR DESCRIPTION
close #124 
close #150 
- 新增付款前的地址選擇流程
  - 點選去付款需要先選擇地址、也可直接新增
- 新增 signal.py 使 payment 當付款流程中斷，下次付款時會自動把狀態是 pending 的改成 fail