### PR TITLE
fix#206: 修正 navbar、orders/urls、group_card 錯誤

### DIFF
--- a/groups/templates/groups/detail.html
+++ b/groups/templates/groups/detail.html
@@ -217,7 +217,7 @@
                 <div class="relative" x-data="{ quantity: 0 }">
                     <input type="hidden" id="product-{{ product.id }}" name="product-{{ product.id }}" x-model="quantity">
                     <div class="absolute w-full h-40 sm:h-44 lg:h-48 z-10">
-                        {% if product.image%}
+                        {% if product.banner %}
                             <img class="object-cover h-full w-full rounded-t-lg" src="{{ product.banner.url }}" alt="{{ product.name }}">
                         {% else %}
                             <div class="h-full w-full bg-gray-300 rounded-t-lg flex items-center justify-center">

--- a/groups/templates/groups/shared/group_card.html
+++ b/groups/templates/groups/shared/group_card.html
@@ -10,7 +10,7 @@
         <!-- Card Content -->
         <div class="flex-1 flex flex-col justify-between p-4 sm:p-6 lg:p-8">
             <div>
-                <h3 class="text-xl lg:text-lg font-semibold">{{ group.name }}</h3>
+                <h3 class="text-xl lg:text-lg font-semibold line-clamp-2">{{ group.name }}</h3>
                 <p class="tertiary-color-500 text-sm mt-2 line-clamp-2">{{ group.description|striptags }}</p>
             </div>
             

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
     ),
     # 確認收貨
     path("my-orders/<int:order_id>/received/", views.received, name="received"),
+    # 確認出貨
+    path("owned-orders/<int:order_id>/shipped/", views.shipped, name="shipped"),
     # 匯出跟團者資訊 Excel
     path(
         "owned-orders/buyer_list_export/<int:group_id>/",

--- a/src/scripts/navigation.js
+++ b/src/scripts/navigation.js
@@ -15,7 +15,10 @@ const navigationControl = () => {
     handleNavbar() {
       const currentScrollY = window.scrollY;
 
-      if (currentScrollY > this.lastScrollY) {
+      // 當滾動到頂部時（scrollY為0或接近0）強制顯示導航欄
+      if (currentScrollY <= 10) {
+        this.showNavbar = true;
+      } else if (currentScrollY > this.lastScrollY) {
         this.showNavbar = false;
       } else {
         this.showNavbar = true;


### PR DESCRIPTION
close #206 
- 修正 navigation.js 對 Safari 感應誤差
- orders/urls 補上 shipped 路徑缺失
- group_card 加上 line-clamp-2 class 避免標題過長