### PR TITLE
ref#215: 第三方登入邏輯修正及優化

### DIFF
--- a/BuyBuddy/settings.py
+++ b/BuyBuddy/settings.py
@@ -267,6 +267,8 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 SOCIALACCOUNT_ADAPTER = "users.adapters.CustomSocialAccountAdapter"
+ACCOUNT_ADAPTER = "users.adapters.CustomAccountAdapter"
+ACCOUNT_EMAIL_VERIFICATION = "none"
 
 # settings.py 末尾
 SITE_ID = 1

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -7,6 +7,7 @@ import { setupTinyMCECsrf } from "./tinymceCsrf.js";
 import { productFormset } from "./productFormset.js";
 import { navigationControl } from "./navigation.js";
 import { addressFormControl } from "./address.js";
+import { googleAuth } from "./googleAuth.js";
 
 window.Alpine = Alpine;
 Alpine.data("messagesControl", messagesControl);
@@ -19,4 +20,5 @@ Alpine.start();
 
 document.addEventListener("DOMContentLoaded", function () {
   setupTinyMCECsrf();
+  googleAuth();
 });

--- a/src/scripts/googleAuth.js
+++ b/src/scripts/googleAuth.js
@@ -1,0 +1,59 @@
+function googleAuth() {
+  // 綁定 Google 登入按鈕點擊事件
+  const googleBtn = document.getElementById('google-signin-btn');
+  if (googleBtn) {
+    googleBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      triggerGoogleSignIn();
+    });
+  }
+}
+
+// 取得 Google Client ID
+async function getClientId() {
+  try{
+    const response = await fetch('/users/js_google_client/')
+    // 如果取得失敗，則跳轉到錯誤頁面
+    if(!response.ok) {
+      window.location.href = '/users/error/?type=config_error';
+      return null;
+    }
+    // 如果取得成功，則返回 Google Client ID
+    const data = await response.json()
+    return data.client_id
+  }catch(error) {
+    // 如果取得失敗，則跳轉到錯誤頁面
+    window.location.href = '/users/error/?type=network_error';
+    return null
+  }
+}
+
+
+// 觸發 Google OAuth2 Popup 登入
+async function triggerGoogleSignIn() {
+  const clientId = await getClientId();
+  if (typeof google !== 'undefined' && google.accounts && google.accounts.oauth2) {
+    const client = google.accounts.oauth2.initCodeClient({
+      client_id: clientId,
+      scope: 'email profile openid',
+      ux_mode: 'popup',
+      callback: handleGoogleOAuthResponse
+    });
+    client.requestCode();
+  }
+}
+
+// Google OAuth2 Popup 登入處理
+function handleGoogleOAuthResponse(response) {
+  if (response.code) {
+    document.getElementById('google_code').value = response.code;
+    document.getElementById('social_provider').value = 'google';
+    document.getElementById('google-oauth2-form').submit();
+  }else if (response.error) {
+    window.location.href = '/users/error/?type=auth_failed';
+    return;
+  }
+}        
+
+
+export { googleAuth };

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -1,29 +1,67 @@
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.contrib import messages
+from allauth.exceptions import ImmediateHttpResponse
+from django.shortcuts import redirect
 
 class CustomAccountAdapter(DefaultAccountAdapter):
-    def is_open_for_signup(self, request):
-        return False
+    def add_message(self, request, level, message_template=None, message_context=None, extra_tags="", message=None):
+        # 攔截預設 messages 模版
+        if message_template == "account/messages/logged_in.txt":
+            return ImmediateHttpResponse()
 
+        # 其他訊息使用原本的邏輯
+        super().add_message(request, level, message_template, message_context, extra_tags, message)
+
+    # 自定義登入後的 行為
+    def post_login(self, request, user, **kwargs):
+        # 檢查登入來源並顯示對應訊息
+        if request.session.get('is_social_signup'):
+            # 註冊路線
+            messages.success(request, f"註冊成功！歡迎加入 BuyBuddy！{user.username}")
+            del request.session['is_social_signup']
+        else:
+            # 傳統登入
+            messages.success(request, f"登入成功！歡迎回來 {user.username}！")
+
+        return redirect('/')
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def is_open_for_signup(self, request, sociallogin):
         # 允許第三方登入創建新帳號
         return True
     
+    # 自定義第三方登入註冊的 行為
     def save_user(self, request, sociallogin, form=None):
         from users.models import User
-        
+        # 取得第三方登入的 email
         email = sociallogin.user.email
+
+        # 過濾出 相同的 email
         existing_user = User.objects.filter(email=email).first()
+        # 如果有 相同的 email
         if existing_user:
-            sociallogin.connect(request, existing_user)
-            
+            if not existing_user.is_verified:
+                messages.error(request, "此信箱已經註冊過，請先驗證信箱")
+                raise ImmediateHttpResponse(redirect('users:sessions_new'))
+            # 連結第三方登入的帳號
+            # 手動建立 SocialAccount 連結
+            from allauth.socialaccount.models import SocialAccount
+            social_account, created = SocialAccount.objects.get_or_create(
+                user=existing_user,
+                provider=sociallogin.account.provider,
+                uid=sociallogin.account.uid,
+                defaults={
+                    'extra_data': sociallogin.account.extra_data
+                }
+            )
+            sociallogin.user = existing_user
+            user = existing_user
+        # 如果沒有 相同的 email
         else:
+            request.session['is_social_signup'] = True
+
+            # 創建新帳號，讓 allauth 完成註冊流程
             user = super().save_user(request, sociallogin, form)
         
-        if not user.is_verified:
-            user.is_verified = True
-            user.save(update_fields=["is_verified"])
-
         return user

--- a/users/templates/users/shared/social_login_buttons.html
+++ b/users/templates/users/shared/social_login_buttons.html
@@ -9,9 +9,10 @@
 
     <div class="flex flex-col justify-center gap-4 mt-4">
         <!-- Google OAuth2 Popup 登入按鈕 -->
-        <form id="google-oauth2-form" action="{% url 'users:google_oauth2' %}" method="post">
+        <form id="google-oauth2-form" action="{% url 'users:social_oauth2' %}" method="post">
             {% csrf_token %}
             <input type="hidden" name="google_code" id="google_code">
+            <input type="hidden" name="social_provider" id="social_provider">
             <button id="google-signin-btn" 
                 class="flex items-center justify-center gap-2 w-full py-2 px-4 border border-[var(--tertiary-color-300)] rounded-full hover:border-[var(--tertiary-color)] hover:bg-[var(--tertiary-color)] transition-colors">
                 <img src="{% static 'assets/google.png' %}" alt="Google" class="w-4 h-4">
@@ -24,49 +25,4 @@
             <span class="text-sm">Line</span>
         </a>
     </div>
-
-
-    <script>
-        // 頁面載入完成後初始化
-        window.addEventListener('load', function() {
-            console.log("Google OAuth2 Popup 初始化完成");
-            
-            // 綁定 Google 登入按鈕點擊事件
-            const googleBtn = document.getElementById('google-signin-btn');
-            if (googleBtn) {
-                googleBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    console.log('觸發 Google OAuth2 Popup 登入');
-                    triggerGoogleSignIn();
-                });
-            }
-        });
-
-        // 觸發 Google OAuth2 Popup 登入
-        function triggerGoogleSignIn() {
-            if (typeof google !== 'undefined' && google.accounts && google.accounts.oauth2) {
-                const client = google.accounts.oauth2.initCodeClient({
-                    client_id: '',
-                    scope: 'email profile openid',
-                    ux_mode: 'popup',
-                    callback: handleGoogleOAuthResponse
-                });
-                client.requestCode();
-            } else {
-                console.error('Google OAuth2 API 尚未載入完成');
-            }
-        }
-
-        // Google OAuth2 Popup 登入處理
-        function handleGoogleOAuthResponse(response) {
-            if (response.code) {
-                // 顯示成功訊息
-                console.log('OAuth2 授權碼回應:', response);
-                document.getElementById('google_code').value = response.code;
-                document.getElementById('google-oauth2-form').submit();
-            } else if (response.error) {
-                console.error('OAuth2 錯誤:', response.error);
-            }
-        }        
-    </script>
 </div>

--- a/users/urls.py
+++ b/users/urls.py
@@ -31,5 +31,7 @@ urlpatterns = [
     path(
         "verify-email/<str:uid>/<str:token>/", views.verify_email, name="verify_email"
     ),
-    path("google-oauth2/", views.google_oauth2, name="google_oauth2"),
+    path("social-oauth2/", views.social_oauth2, name="social_oauth2"),
+    path("js_google_client/", views.js_google_client, name="js_google_client"),
+    path("error/", views.handle_error, name="handle_error"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -23,8 +23,31 @@ import os
 import requests
 from allauth.socialaccount.models import SocialLogin, SocialAccount
 from allauth.socialaccount.helpers import complete_social_login
+from django.http import JsonResponse
+from allauth.exceptions import ImmediateHttpResponse
 
 
+def js_google_client(request):
+    return JsonResponse({"client_id": os.getenv("GOOGLE_CLIENT_ID")})
+
+def handle_error(request):
+    error_messages = {
+        'config_error': '系統配置載入失敗，請稍後再試',
+        'network_error': '網路連線異常，請檢查網路狀態',
+        'unknown': '發生未知錯誤，請聯絡客服',
+        'auth_failed': '登入取消，請稍後再試',
+    }
+    if request.GET.get("type") == "config_error":
+        messages.error(request, error_messages['config_error'])
+        return redirect("users:sessions_new")
+    elif request.GET.get("type") == "network_error":
+        messages.error(request, error_messages['network_error'])
+        return redirect("users:sessions_new")
+    elif request.GET.get("type") == "auth_failed":
+        messages.info(request, error_messages['auth_failed'])
+        return redirect("users:sessions_new")
+    messages.error(request, error_messages['unknown'])
+    return redirect("users:sessions_new")
 
 def send_verification_mail(request, user, email):
     try:
@@ -153,7 +176,7 @@ def sessions_delete(request):
 @require_POST
 @login_required
 def check_email(request):
-    # TODO: 個人頁面需要二次驗證
+    # TODO 個人頁面需要二次驗證
     user = request.user
 
     if user.is_verified:
@@ -486,42 +509,39 @@ def address_cancel(request, address_id):
     )
 
 
-# TODO: 發送授權碼到後端進行驗證和登入
-def google_oauth2(request):
-    
-
+# TODO: 接收前端的授權碼進行驗證和登入
+def social_oauth2(request):
     # 先加入調試訊息
     code = request.POST.get("google_code")
-    print(f"收到JWT: {code}")
-    print(f"請求方法: {request.method}, 授權碼")
-    print(f"用戶已登入: {request.user.is_authenticated}")
 
-    if code:
-        try:
-            # TODO: 在這裡處理 Google 授權碼，完成登入流程
-            
-            # 1. 用授權碼換取 access token
-            tokens = token_code_handler(code)
-            print(f"取得 tokens: {tokens.keys()}")
+    if not code:
+        messages.error(request, '過程中斷，請重新嘗試')
+        return redirect("users:sessions_new")
+    
+    try:
+        # 處理 Google 授權碼，完成登入流程
+        
+        # 1. 用授權碼換取 access token
+        tokens = token_code_handler(code)
 
-            # 2. 用 access token 取得用戶資料
-            user_info = get_user_info(tokens['access_token'])
-            print(f"取得用戶資料: {user_info}")
-            
-
-            # 3. 創建或找到用戶並登入
-            social_login = create_google_login(user_info)
-
-            return complete_social_login(request, social_login)
-        except Exception as e:
-            import traceback
-            print("完整錯誤堆疊:")
-            traceback.print_exc()
-            print(f"Google OAuth2 錯誤: {e}")
-            return redirect("users:new")
-    else:
-        print('授權碼不存在')
-        return redirect("users:new")  # 重導向到登入頁面而不是註冊頁面
+        # 2. 用 access token 取得用戶資料
+        user_info = get_user_info(tokens['access_token'])
+        
+        # 3. 前往登入或註冊
+        social_login = create_google_login(user_info)
+        return complete_social_login(request, social_login)
+    except ImmediateHttpResponse:
+        # 讓 allauth 的重導向正常通過
+        raise
+    except (ValueError, KeyError) as e:
+      messages.error(request, 'Google 授權失敗，請稍後再試')
+      return redirect("users:sessions_new")
+    except requests.RequestException as e:
+        messages.error(request, '網路連線失敗，請稍後再試')
+        return redirect("users:sessions_new")
+    except Exception as e:
+        messages.error(request, '系統錯誤，請稍後再試')
+        return redirect("users:sessions_new")
 
 def token_code_handler(code):
     # 設定 OAuth 流程
@@ -580,12 +600,10 @@ def create_google_login(user_info):
     user = User()
     user.email = user_info.get('email', '')
     user.username = user_info.get('email', '')  # 用 email 作為 username
-    user.first_name = user_info.get('given_name', '')
-    user.last_name = user_info.get('given_name', '')
+    user.is_verified = True
 
     # 關聯 User 和 SocialAccount
     social_login.user = user
     social_login.account.user = user
     
     return social_login
-


### PR DESCRIPTION
close #215 
- 第三方登入註冊的 flash message 內容優化
- 前端的環境變數改使用 fetch 獲得
- 已註冊用戶必須驗證過信箱才能使用第三方登入
- 驗證過後使用第三方登入，會直接互相綁定
- 使用第三方登入用戶不能使用帳號密碼登入
- 優化錯誤處理跟用戶提示


https://github.com/user-attachments/assets/78516169-70b9-4862-af91-54715415c99e


