### PR TITLE
feat#197: 新增忘記密碼功能

### DIFF
--- a/BuyBuddy/settings.py
+++ b/BuyBuddy/settings.py
@@ -26,7 +26,7 @@ ALLOWED_HOSTS = [
     "buybuddy.site",
     "www.buybuddy.site",
     os.getenv("HOSTNAME"),
-    "cce894edfc1c.ngrok-free.app"
+    "cce894edfc1c.ngrok-free.app",
 ]
 
 CSRF_TRUSTED_ORIGINS = [
@@ -63,7 +63,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
-    'widget_tweaks',
+    "widget_tweaks",
 ]
 
 MIDDLEWARE = [
@@ -123,25 +123,25 @@ AUTH_USER_MODEL = "users.User"
 if DEBUG:
     AUTH_PASSWORD_VALIDATORS = [
         {
-            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-            'OPTIONS': {
-                'min_length': 8,
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+            "OPTIONS": {
+                "min_length": 8,
             },
         },
     ]
 else:
     AUTH_PASSWORD_VALIDATORS = [
         {
-            'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
         },
         {
-            'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+            "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
         },
     ]
 
@@ -201,13 +201,13 @@ else:
 # EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 # DEFAULT_FROM_EMAIL = 'noreply@yoursite.com'
 
-
 # 真實發信
 # Anymail 設定
 ANYMAIL = {
     "MAILGUN_API_KEY": os.environ.get("MAILGUN_API_KEY"),
     "MAILGUN_SENDER_DOMAIN": os.environ.get("MAILGUN_SENDER_DOMAIN"),
 }
+
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
 
@@ -268,9 +268,17 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
+
+ACCOUNT_ADAPTER = "users.adapters.CustomAccountAdapter"
+
+
 SOCIALACCOUNT_ADAPTER = "users.adapters.CustomSocialAccountAdapter"
 ACCOUNT_ADAPTER = "users.adapters.CustomAccountAdapter"
 ACCOUNT_EMAIL_VERIFICATION = "none"
+ACCOUNT_FORMS = {
+    "reset_password": "users.forms.MyResetPasswordForm",
+    "reset_password_from_key": "users.forms.CustomResetPasswordFromKeyForm",
+}
 
 # settings.py 末尾
 SITE_ID = 1

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,0 +1,25 @@
+{% extends 'layouts/default.html' %}
+
+{% block content %}
+<div class="flex flex-col items-center">
+    <div class="w-full max-w-md px-14">
+        <h1 class="text-xl lg:text-lg font-bold mt-5 mb-4 text-center">忘記密碼</h1>
+        <p class="text-center text-gray-500 mb-6">請輸入您註冊時使用的電子郵件地址，我們將會寄送一封包含重設密碼連結的信件給您。</p>
+        <form method="post" action="{% url 'account_reset_password' %}" class="flex flex-col gap-4 sm:gap-6" novalidate>
+            {% csrf_token %}
+            <div class="mb-2">
+                <div class="relative">
+                    <svg class="absolute left-6 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#7c7c7c" viewBox="0 0 256 256"><path d="M224,48H32a8,8,0,0,0-8,8V192a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A8,8,0,0,0,224,48ZM203.43,64,128,133.15,52.57,64ZM216,192H40V74.19l82.59,75.71a8,8,0,0,0,10.82,0L216,74.19V192Z"></path></svg>
+                    <input type="email" name="email" placeholder="請輸入信箱" class="text-sm w-full py-2 px-4 pl-14 border-[1.5px] border-[var(--tertiary-color-300)] rounded-full focus:outline-none transition-colors h-[42px]" required id="id_email">
+                </div>
+                {% for error in form.email.errors %}
+                    <div class="text-[var(--red-color-700)] text-sm ml-8 mt-2 min-h-[20px]">{{ error }}</div>
+                {% endfor %}
+            </div>
+            <div class="flex justify-center mt-2 sm:mt-6">
+                <button class="main-btn" type="submit">傳送重設連結</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,0 +1,11 @@
+{% extends 'layouts/default.html' %}
+
+{% block content %}
+<div class="flex flex-col items-center text-center py-10">
+    <div class="w-full max-w-md px-14">
+        <h1 class="text-xl lg:text-lg font-bold mt-5 mb-4">重設連結已寄出</h1>
+        <p class="text-gray-600 mb-8">我們已經將重設密碼的說明寄到您的電子信箱。請檢查您的收件匣（包含垃圾郵件），並點擊信中的連結來設定新密碼。</p>
+        <a href="{% url 'pages:homepage' %}" class="main-btn">返回首頁</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -1,0 +1,72 @@
+{% extends 'layouts/default.html' %} {% block content %}
+<div class="flex flex-col items-center">
+  <div class="w-full max-w-md px-14">
+    <h1 class="text-xl lg:text-lg font-bold mt-5 mb-4 text-center">
+      設定新密碼
+    </h1>
+    {% if form %}
+    <p class="text-center text-gray-500 mb-6">
+      請輸入您的新密碼兩次，以確保輸入正確。
+    </p>
+    <form method="post" action="{{ action_url }}" class="flex flex-col gap-4 sm:gap-6" novalidate>
+      {% csrf_token %}
+      
+      <div class="mb-2">
+        <div class="relative">
+          <svg class="absolute left-6 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#7c7c7c" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
+          <input
+            type="password"
+            name="password1"
+            id="id_password1"
+            placeholder="請輸入新密碼"
+            required
+            class="text-sm w-full py-2 px-4 pl-14 border-[1.5px] rounded-full focus:outline-none transition-colors h-[42px] {% if form.password1.errors %} border-[var(--red-color-700)] {% else %} border-[var(--tertiary-color-300)] {% endif %}"
+            {% if form.password1.errors %} aria-invalid="true" aria-describedby="password1-errors" {% endif %}
+          >
+        </div>
+        <div id="password1-errors">
+          {% for error in form.password1.errors %}
+          <div class="text-[var(--red-color-700)] text-sm ml-8 mt-2 min-h-[20px]">{{ error }}</div>
+          {% endfor %}
+        </div>
+      </div>
+
+      
+      <div class="mb-2">
+        <div class="relative">
+          <svg class="absolute left-6 top-1/2 -translate-y-1/2" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#7c7c7c" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
+          <input
+            type="password"
+            name="password2"
+            id="id_password2"
+            placeholder="再次確認新密碼"
+            required
+            class="text-sm w-full py-2 px-4 pl-14 border-[1.5px] rounded-full focus:outline-none transition-colors h-[42px] {% if form.password2.errors %} border-[var(--red-color-700)] {% else %} border-[var(--tertiary-color-300)] {% endif %}"
+            {% if form.password2.errors %} aria-invalid="true" aria-describedby="password2-errors" {% endif %}
+          >
+        </div>
+        <div id="password2-errors">
+          {% for error in form.password2.errors %}
+          <div class="text-[var(--red-color-700)] text-sm ml-8 mt-2 min-h-[20px]">{{ error }}</div>
+          {% endfor %}
+        </div>
+      </div>
+
+      
+      {% for error in form.non_field_errors %}
+      <div class="text-[var(--red-color-700)] text-sm text-center mt-2 min-h-[20px]">{{ error }}</div>
+      {% endfor %}
+
+      <div class="flex justify-center mt-2 sm:mt-6">
+        <button class="main-btn" type="submit">儲存新密碼</button>
+      </div>
+    </form>
+    {% else %}
+    <p class="text-center text-red-500">此密碼重設連結無效，可能已被使用或已過期。</p>
+    <div class="flex justify-center mt-8">
+      <a href="{% url 'account_reset_password' %}" class="main-btn">重新申請重設密碼</a>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/account/password_reset_from_key_done.html
+++ b/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,11 @@
+{% extends 'layouts/default.html' %}
+
+{% block content %}
+<div class="flex flex-col items-center text-center py-10">
+    <div class="w-full max-w-md px-14">
+        <h1 class="text-xl lg:text-lg font-bold mt-5 mb-4">密碼已成功重設</h1>
+        <p class="text-gray-600 mb-8">您的密碼已經更新。現在您可以使用新密碼登入您的帳號。</p>
+        <a href="{% url 'users:sessions_new' %}" class="main-btn">前往登入頁面</a>
+    </div>
+</div>
+{% endblock %}

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -4,36 +4,101 @@ from django.contrib import messages
 from allauth.exceptions import ImmediateHttpResponse
 from django.shortcuts import redirect
 
+
 class CustomAccountAdapter(DefaultAccountAdapter):
-    def add_message(self, request, level, message_template=None, message_context=None, extra_tags="", message=None):
+    def add_message(
+        self,
+        request,
+        level,
+        message_template=None,
+        message_context=None,
+        extra_tags="",
+        message=None,
+    ):
         # 攔截預設 messages 模版
         if message_template == "account/messages/logged_in.txt":
             return ImmediateHttpResponse()
 
+
+from django.conf import settings
+from anymail.message import AnymailMessage
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def send_password_reset_email_with_template(email: str, reset_url: str):
+    template_name = "重設密碼信"
+    if not template_name:
+        logger.error(
+            "Mailgun password reset template name is not configured in settings."
+        )
+        return
+
+    try:
+        msg = AnymailMessage(
+            template_id=template_name,  # 使用您在 settings 中定義的模板名稱
+            to=[email],
+            from_email=settings.DEFAULT_FROM_EMAIL,
+        )
+        # 將 reset_url 傳遞給模板中的 {{reset_url}} 變數
+        msg.merge_global_data = {
+            "reset_url": reset_url,
+        }
+        msg.send()
+    except Exception as e:
+        logger.exception(f"寄送重設密碼信時發生錯誤: {e}")
+        return False
+
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    def send_mail(self, template_prefix, email, context):
+        # 判斷是否為密碼重設信件
+        if template_prefix == "account/email/password_reset_key":
+            reset_url = context.get("password_reset_url")
+            if reset_url:
+                # 如果是，就呼叫我們新的、風格一致的函數
+                send_password_reset_email_with_template(email, reset_url)
+            else:
+                logger.warning(
+                    "password_reset_url not found in context for password reset email."
+                )
+                super().send_mail(template_prefix, email, context)
+        else:
+            # 其他所有信件（如帳號驗證信）都使用 allauth 的預設方法
+            super().send_mail(template_prefix, email, context)
+
+    def is_open_for_signup(self, request):
+        return False
+
         # 其他訊息使用原本的邏輯
-        super().add_message(request, level, message_template, message_context, extra_tags, message)
+        super().add_message(
+            request, level, message_template, message_context, extra_tags, message
+        )
 
     # 自定義登入後的 行為
     def post_login(self, request, user, **kwargs):
         # 檢查登入來源並顯示對應訊息
-        if request.session.get('is_social_signup'):
+        if request.session.get("is_social_signup"):
             # 註冊路線
             messages.success(request, f"註冊成功")
-            del request.session['is_social_signup']
+            del request.session["is_social_signup"]
         else:
             # 傳統登入
             messages.success(request, f"登入成功")
 
-        return redirect('/')
+        return redirect("/")
+
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def is_open_for_signup(self, request, sociallogin):
         # 允許第三方登入創建新帳號
         return True
-    
+
     # 自定義第三方登入註冊的 行為
     def save_user(self, request, sociallogin, form=None):
         from users.models import User
+
         # 取得第三方登入的 email
         email = sociallogin.user.email
 
@@ -43,25 +108,28 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         if existing_user:
             if not existing_user.is_verified:
                 messages.error(request, "此信箱已經註冊過，請先驗證信箱")
-                raise ImmediateHttpResponse(redirect('users:sessions_new'))
+                raise ImmediateHttpResponse(redirect("users:sessions_new"))
             # 連結第三方登入的帳號
             # 手動建立 SocialAccount 連結
             from allauth.socialaccount.models import SocialAccount
+
             social_account, created = SocialAccount.objects.get_or_create(
                 user=existing_user,
                 provider=sociallogin.account.provider,
                 uid=sociallogin.account.uid,
-                defaults={
-                    'extra_data': sociallogin.account.extra_data
-                }
+                defaults={"extra_data": sociallogin.account.extra_data},
             )
             sociallogin.user = existing_user
             user = existing_user
         # 如果沒有 相同的 email
         else:
-            request.session['is_social_signup'] = True
+            request.session["is_social_signup"] = True
 
             # 創建新帳號，讓 allauth 完成註冊流程
             user = super().save_user(request, sociallogin, form)
-        
+
+        if not user.is_verified:
+            user.is_verified = True
+            user.save(update_fields=["is_verified"])
+
         return user

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,4 +1,10 @@
-from django.forms import ModelForm, FileInput, TextInput, CheckboxInput, modelformset_factory
+from django.forms import (
+    ModelForm,
+    FileInput,
+    TextInput,
+    CheckboxInput,
+    modelformset_factory,
+)
 from .models import User, UserAddress
 from django import forms
 from django.core.validators import MinLengthValidator
@@ -7,6 +13,13 @@ from django.conf import settings
 from pathlib import Path
 import json
 import re
+from allauth.account.forms import ResetPasswordForm
+from allauth.account.forms import ResetPasswordKeyForm
+from django.contrib.auth.password_validation import (
+    get_default_password_validators,
+    MinimumLengthValidator,
+)
+from django.core.exceptions import ValidationError
 
 # 讀出縣市區域的
 _DATA_PATH = Path(settings.BASE_DIR) / "public" / "assets" / "taiwan-districts.json"
@@ -67,7 +80,7 @@ class RegistrationForm(UserCreationForm):
         }
 
         self.error_messages = {
-            'password_mismatch': "兩次輸入的密碼不一致",
+            "password_mismatch": "兩次輸入的密碼不一致",
         }
 
 
@@ -223,3 +236,117 @@ UserAddressFormSet = modelformset_factory(
     form=UserAddressForm,
     extra=0,
 )
+
+
+class MyResetPasswordForm(ResetPasswordForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # 這裡的 'email' 就是該頁面的必填欄位
+        self.fields["email"].error_messages.update(
+            {
+                "required": "此欄位為必填",
+                "invalid": "請輸入有效的電子郵件地址",
+            }
+        )
+
+
+class CustomResetPasswordFromKeyForm(ResetPasswordKeyForm):
+    error_messages = {
+        "password_mismatch": "兩次輸入的密碼不一致，請再確認",
+    }
+    length_template = "密碼需要 {min_len} 個字符"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for name in ("password1", "password2"):
+            f = self.fields[name]
+            f.label = "新密碼" if name == "password1" else "再次輸入新密碼"
+            f.error_messages["required"] = "此欄位為必填"
+            f.validators.clear()
+            f.help_text = ""
+            f.min_length = None
+
+    def clean_password1(self):
+        return self.cleaned_data.get("password1")
+
+    def clean_password2(self):
+        return self.cleaned_data.get("password2")
+
+    def clean(self):
+        p1 = self.cleaned_data.get("password1")
+        p2 = self.cleaned_data.get("password2")
+
+        # 任一欄沒填 -> 交給 required 中文
+        if not p1 or not p2:
+            return self.cleaned_data
+
+        # 先清掉可能殘留的欄位錯誤
+        if hasattr(self, "_errors"):
+            self._errors.pop("password1", None)
+            self._errors.pop("password2", None)
+
+        # 兩次不同 -> 兩欄都掛中文
+        if p1 != p2:
+            msg = self.error_messages["password_mismatch"]
+            self.add_error("password1", msg)
+            self.add_error("password2", msg)
+            return self.cleaned_data
+
+        # 長度不足 -> 兩欄都掛中文
+        min_len = self._get_min_length()
+        if len(p2) < min_len:
+            msg = self.length_template.format(min_len=min_len)
+            self.add_error("password1", msg)
+            self.add_error("password2", msg)
+
+        return self.cleaned_data
+
+    # 核心：攔截任何被加上的錯誤，換成我們要的中文，且兩欄都顯示
+    def add_error(self, field, error):
+        # 只處理密碼兩欄
+        if field in ("password1", "password2"):
+            # 1) 帶 code 的錯誤（例如密碼太短）
+            if isinstance(error, ValidationError):
+                codes = {getattr(e, "code", None) for e in error.error_list}
+                # 攔截「密碼太短」
+                if "password_too_short" in codes:
+                    msg = self.length_template.format(min_len=self._get_min_length())
+                    super().add_error("password1", msg)
+                    super().add_error("password2", msg)
+                    return
+                # 處理其他密碼強度相關的錯誤並提供中文訊息
+                if "password_too_common" in codes:
+                    msg = "您的密碼太過常見。"
+                elif "password_entirely_numeric" in codes:
+                    msg = "您的密碼不能全部是數字。"
+                elif "password_too_similar" in codes:
+                    msg = "您的密碼與您的個人資訊太過相似。"
+                else:
+                    # 對於未明確處理的驗證碼，保留原始錯誤，避免安全漏洞
+                    super().add_error(field, error)
+                    return
+
+                super().add_error("password1", msg)
+                super().add_error("password2", msg)
+                return
+            # 有些版本會用字串訊息；一併攔掉（直角與彎引號都處理）
+            if isinstance(error, str):
+                if (
+                    "same password each time" in error
+                    or "didn't match" in error
+                    or "didn’t match" in error
+                ):
+                    msg = self.error_messages["password_mismatch"]
+                    super().add_error("password1", msg)
+                    super().add_error("password2", msg)
+                    return
+
+        # 其他情況維持原行為（例如 required）
+        return super().add_error(field, error)
+
+    def _get_min_length(self) -> int:
+        # 讀取 settings.AUTH_PASSWORD_VALIDATORS 的長度設定；找不到就用 8
+        for v in get_default_password_validators():
+            if isinstance(v, MinimumLengthValidator):
+                return getattr(v, "min_length", 8)
+        return 8

--- a/users/signals.py
+++ b/users/signals.py
@@ -2,6 +2,8 @@ from django.db.models.signals import post_save, pre_save, pre_delete
 from django.dispatch import receiver
 from django.conf import settings
 from .models import UserAddress, DefaultAddressRequiredError
+from allauth.account.signals import password_reset
+from django.contrib import messages
 
 User = settings.AUTH_USER_MODEL
 
@@ -46,3 +48,13 @@ def ensure_default_before_save(sender, instance: UserAddress, **kwargs):
 def ensure_default_on_delete(sender, instance: UserAddress, **kwargs):
     if not _has_other_default(instance.user, exclude_pk=instance.pk):
         raise DefaultAddressRequiredError("無法刪除預設地址")
+
+
+@receiver(password_reset)
+def on_password_reset(sender, request, **kwargs):
+    # By default, allauth adds a success message.
+    # We clear existing messages and add our own custom one.
+    storage = messages.get_messages(request)
+    list(storage)
+
+    messages.success(request, "新密碼已儲存成功，請使用新密碼登入您的帳號")

--- a/users/templates/users/sessions_new.html
+++ b/users/templates/users/sessions_new.html
@@ -43,20 +43,25 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="flex items-center gap-2 ml-2 mt-2">
-                <label class="relative w-6 h-6 cursor-pointer flex items-center">
-                    <input type="checkbox" 
-                           id="remember_me" 
-                           name="remember_me" 
-                           class="peer absolute opacity-0 w-full h-full cursor-pointer">
-                    <svg class="absolute w-6 h-6 transition-opacity fill-[var(--tertiary-color-300)] peer-checked:fill-[var(--main-color)]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-                        <path d="M230,128A102,102,0,1,1,128,26,102.12,102.12,0,0,1,230,128Zm-12,0a90,90,0,1,0-90,90A90.1,90.1,0,0,0,218,128Z"></path>
-                    </svg>
-                    <svg class="absolute w-6 h-6 opacity-0 peer-checked:opacity-100 transition-opacity fill-[var(--main-color)]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-                        <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"></path>
-                    </svg>
-                </label>
-                <label for="remember_me" class="cursor-pointer text-[var(--tertiary-color-500)] text-sm">記住我</label>
+            <div class="flex items-center justify-between gap-2 ml-2 mt-2">
+                <div class="flex items-center gap-2">
+                    <label class="relative w-6 h-6 cursor-pointer flex items-center">
+                        <input type="checkbox" 
+                               id="remember_me" 
+                               name="remember_me" 
+                               class="peer absolute opacity-0 w-full h-full cursor-pointer">
+                        <svg class="absolute w-6 h-6 transition-opacity fill-[var(--tertiary-color-300)] peer-checked:fill-[var(--main-color)]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+                            <path d="M230,128A102,102,0,1,1,128,26,102.12,102.12,0,0,1,230,128Zm-12,0a90,90,0,1,0-90,90A90.1,90.1,0,0,0,218,128Z"></path>
+                        </svg>
+                        <svg class="absolute w-6 h-6 opacity-0 peer-checked:opacity-100 transition-opacity fill-[var(--main-color)]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+                            <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm45.66,85.66-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35a8,8,0,0,1,11.32,11.32Z"></path>
+                        </svg>
+                    </label>
+                    <label for="remember_me" class="cursor-pointer text-[var(--tertiary-color-500)] text-sm">記住我</label>
+                </div>
+                <div class="text-sm pr-2">
+                    <a href="{% url 'account_reset_password' %}" class="border-b-2">忘記密碼？</a>
+                </div>
             </div>
             <div class="flex justify-center mt-2 sm:mt-6">
                 <button class="main-btn">

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,24 +1,25 @@
-from django.urls import path
+from django.urls import path, re_path, include
 from . import views
+from users.views import custom_password_reset_from_key
 
 app_name = "users"
 
 urlpatterns = [
-    path('profiles/', views.profiles, name="profiles"),
-    path('profiles/edit/', views.profiles_edit, name="profiles_edit"),
-    path('profiles/address/create/', views.address_create, name="address_create"),
+    path("profiles/", views.profiles, name="profiles"),
+    path("profiles/edit/", views.profiles_edit, name="profiles_edit"),
+    path("profiles/address/create/", views.address_create, name="address_create"),
     path(
-        'profiles/address/<int:address_id>/edit/',
+        "profiles/address/<int:address_id>/edit/",
         views.address_edit,
         name="address_edit",
     ),
     path(
-        'profiles/address/<int:address_id>/delete/',
+        "profiles/address/<int:address_id>/delete/",
         views.address_delete,
         name="address_delete",
     ),
     path(
-        'profiles/address/<int:address_id>/cancel/',
+        "profiles/address/<int:address_id>/cancel/",
         views.address_cancel,
         name="address_cancel",
     ),
@@ -27,6 +28,11 @@ urlpatterns = [
     path("sessions/new/", views.sessions_new, name="sessions_new"),
     path("sessions/delete/", views.sessions_delete, name="sessions_delete"),
     path("sessions/", views.sessions_create, name="sessions_create"),
+    path(
+        "password/reset/success/",
+        views.password_reset_redirect,
+        name="password_reset_success",
+    ),
     path("check-email/", views.check_email, name="check_email"),
     path(
         "verify-email/<str:uid>/<str:token>/", views.verify_email, name="verify_email"
@@ -34,4 +40,9 @@ urlpatterns = [
     path("social-oauth2/", views.social_oauth2, name="social_oauth2"),
     path("js_google_client/", views.js_google_client, name="js_google_client"),
     path("error/", views.handle_error, name="handle_error"),
+    re_path(
+        r"^accounts/password/reset/key/(?:(?P<uid>[^/]+)-)?(?P<key>[^/]+)/$",
+        custom_password_reset_from_key,
+        name="account_reset_password_from_key",
+    ),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -26,28 +26,51 @@ from allauth.socialaccount.helpers import complete_social_login
 from django.http import JsonResponse
 from allauth.exceptions import ImmediateHttpResponse
 
+from django.http import HttpResponse, HttpRequest
+from allauth.account.views import PasswordResetFromKeyView
+from .forms import CustomResetPasswordFromKeyForm
+
+
+def custom_password_reset_from_key(request, uid=None, key=None):
+    if request.method == "POST":
+        form = CustomResetPasswordFromKeyForm(request.POST)
+        if form.is_valid():
+            form.save()  # 更新密碼
+            messages.success(request, "密碼已重置成功")
+            return redirect("account_login")  # 或你想要的頁面
+    else:
+        form = CustomResetPasswordFromKeyForm(initial={"uid": uid, "key": key})
+
+    return render(
+        request,
+        "account/password_reset_from_key.html",
+        {"form": form},
+    )
+
 
 def js_google_client(request):
     return JsonResponse({"client_id": os.getenv("GOOGLE_CLIENT_ID")})
 
+
 def handle_error(request):
     error_messages = {
-        'config_error': '系統配置載入失敗，請稍後再試',
-        'network_error': '網路連線異常，請檢查網路狀態',
-        'unknown': '發生未知錯誤，請聯絡客服',
-        'auth_failed': '登入取消，請稍後再試',
+        "config_error": "系統配置載入失敗，請稍後再試",
+        "network_error": "網路連線異常，請檢查網路狀態",
+        "unknown": "發生未知錯誤，請聯絡客服",
+        "auth_failed": "登入取消，請稍後再試",
     }
     if request.GET.get("type") == "config_error":
-        messages.error(request, error_messages['config_error'])
+        messages.error(request, error_messages["config_error"])
         return redirect("users:sessions_new")
     elif request.GET.get("type") == "network_error":
-        messages.error(request, error_messages['network_error'])
+        messages.error(request, error_messages["network_error"])
         return redirect("users:sessions_new")
     elif request.GET.get("type") == "auth_failed":
-        messages.info(request, error_messages['auth_failed'])
+        messages.info(request, error_messages["auth_failed"])
         return redirect("users:sessions_new")
-    messages.error(request, error_messages['unknown'])
+    messages.error(request, error_messages["unknown"])
     return redirect("users:sessions_new")
+
 
 def send_verification_mail(request, user, email):
     try:
@@ -441,7 +464,6 @@ def address_create(request):
 
             # 代表是從選擇地址來的
             if order_id:
-
                 # 轉址把 order 和 address 帶過去
                 url = f"{reverse('orders:check_order', args=[order_id])}?address_id={new_address_form.id}"
 
@@ -515,18 +537,18 @@ def social_oauth2(request):
     code = request.POST.get("google_code")
 
     if not code:
-        messages.error(request, '過程中斷，請重新嘗試')
+        messages.error(request, "過程中斷，請重新嘗試")
         return redirect("users:sessions_new")
-    
+
     try:
         # 處理 Google 授權碼，完成登入流程
-        
+
         # 1. 用授權碼換取 access token
         tokens = token_code_handler(code)
 
         # 2. 用 access token 取得用戶資料
-        user_info = get_user_info(tokens['access_token'])
-        
+        user_info = get_user_info(tokens["access_token"])
+
         # 3. 前往登入或註冊
         social_login = create_google_login(user_info)
         return complete_social_login(request, social_login)
@@ -534,14 +556,15 @@ def social_oauth2(request):
         # 讓 allauth 的重導向正常通過
         raise
     except (ValueError, KeyError) as e:
-      messages.error(request, 'Google 授權失敗，請稍後再試')
-      return redirect("users:sessions_new")
+        messages.error(request, "Google 授權失敗，請稍後再試")
+        return redirect("users:sessions_new")
     except requests.RequestException as e:
-        messages.error(request, '網路連線失敗，請稍後再試')
+        messages.error(request, "網路連線失敗，請稍後再試")
         return redirect("users:sessions_new")
     except Exception as e:
-        messages.error(request, '系統錯誤，請稍後再試')
+        messages.error(request, "系統錯誤，請稍後再試")
         return redirect("users:sessions_new")
+
 
 def token_code_handler(code):
     # 設定 OAuth 流程
@@ -556,28 +579,30 @@ def token_code_handler(code):
 
     flow = Flow.from_client_config(
         client_config,
-        scopes=['https://www.googleapis.com/auth/userinfo.email', 
-        'https://www.googleapis.com/auth/userinfo.profile',
-        'openid']
+        scopes=[
+            "https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "openid",
+        ],
     )
-    
+
     # 設定重導向 URI（必須與 Google Console 設定一致）
-    flow.redirect_uri = 'postmessage'  # 彈窗模式用這個
-    
+    flow.redirect_uri = "postmessage"  # 彈窗模式用這個
+
     # 用授權碼換取 token
     flow.fetch_token(code=code)
-    
+
     return {
-        'access_token': flow.credentials.token,
-        'id_token': flow.credentials.id_token,
-        'refresh_token': flow.credentials.refresh_token,
+        "access_token": flow.credentials.token,
+        "id_token": flow.credentials.id_token,
+        "refresh_token": flow.credentials.refresh_token,
     }
 
 
 def get_user_info(access_token):
     response = requests.get(
-        'https://www.googleapis.com/oauth2/v3/userinfo',
-        headers={'Authorization': f'Bearer {access_token}'}
+        "https://www.googleapis.com/oauth2/v3/userinfo",
+        headers={"Authorization": f"Bearer {access_token}"},
     )
 
     if response.status_code != 200:
@@ -585,25 +610,29 @@ def get_user_info(access_token):
 
     return response.json()
 
+
 def create_google_login(user_info):
     # 創建 SocialLogin
     social_login = SocialLogin()
-    
+
     # 創建 SocialAccount
     social_login.account = SocialAccount()
-    social_login.account.provider = 'google'
-    social_login.account.uid = user_info.get('sub')  # Google 用戶 ID
+    social_login.account.provider = "google"
+    social_login.account.uid = user_info.get("sub")  # Google 用戶 ID
     social_login.account.extra_data = user_info
-    
 
     # 創建 暫時的 User
     user = User()
-    user.email = user_info.get('email', '')
-    user.username = user_info.get('email', '')  # 用 email 作為 username
+    user.email = user_info.get("email", "")
+    user.username = user_info.get("email", "")  # 用 email 作為 username
     user.is_verified = True
 
     # 關聯 User 和 SocialAccount
     social_login.user = user
     social_login.account.user = user
-    
+
     return social_login
+
+
+def password_reset_redirect(request):
+    return redirect("users:sessions_new")


### PR DESCRIPTION
close #197 
 - 覆寫 allauth 預設的 ResetPasswordForm 與 ResetPasswordKeyForm
 - 主要目的是將錯誤訊息與欄位標籤改成中文
 - 忘記密碼申請頁面：
    - 新增 MyRestPasswordForm (繼承自 allauth.account.forms.ResetPasswordForm)
    - 在 __init__ 中修改 self.fields["email"].error_messages
    - 將 required、invalid 等錯誤訊息改為中文

 - 重設密碼頁面
    - 新增 CustomResetPasswordFromKeyForm (繼承自 allauth.account.forms.ResetPasswordKeyForm)
    - 在 __init__ 中調整欄位標籤（如「新密碼」、「再次輸入新密碼」）
    - 覆寫 clean 方法，自訂檢查邏輯與錯誤訊息（例如兩次密碼不一致時顯示中文提示）
 - Mailgun 增加「重設密碼信」的 templates
 
 - 申請密碼頁面：
<img width="842" height="476" alt="截圖 2025-09-12 下午3 46 46" src="https://github.com/user-attachments/assets/929641c5-4aab-44c6-bc3b-5346762cb3cc" />
<img width="842" height="476" alt="截圖 2025-09-12 下午3 46 53" src="https://github.com/user-attachments/assets/da628edf-6ca0-46d9-ac8e-be4d5dce9339" />

 - 重設密碼頁面：
<img width="842" height="476" alt="截圖 2025-09-12 下午3 46 22" src="https://github.com/user-attachments/assets/9ea0a565-ebcc-4091-af30-f21fa67e62e1" />
<img width="842" height="476" alt="截圖 2025-09-12 下午3 46 16" src="https://github.com/user-attachments/assets/9f70a422-0083-482d-9a7b-39202d01ab54" />
<img width="842" height="476" alt="截圖 2025-09-12 下午3 46 01" src="https://github.com/user-attachments/assets/740f2acd-e5c3-4653-a517-28cdee52e693" />


 - 重設密碼信：
<img width="1003" height="509" alt="截圖 2025-09-12 下午3 35 48" src="https://github.com/user-attachments/assets/dcc434fd-ddb9-4727-bff3-0f27fc5471b7" />

