### PR TITLE
fix#239: Google第三方登入彈窗與導向問題

### DIFF
--- a/BuyBuddy/settings.py
+++ b/BuyBuddy/settings.py
@@ -287,6 +287,7 @@ LOGOUT_REDIRECT_URL = "/"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
+GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 
 # 藍新金流設定
 NEWEBPAY_MERCHANT_ID = os.getenv("NEWEBPAY_MERCHANT_ID")
@@ -304,4 +305,8 @@ if DEBUG:
     ]
     # 允許跨域請求攜帶認證資訊 (cookies, session 等)
     CORS_ALLOW_CREDENTIALS = True
-
+    # ngrok 域名
+    HOSTNAME = os.getenv("NGROK_HOSTNAME")
+    ALLOWED_HOSTS += [
+        os.getenv("NGROK_HOSTNAME"),
+    ]

--- a/src/scripts/googleAuth.js
+++ b/src/scripts/googleAuth.js
@@ -10,9 +10,10 @@ function googleAuth() {
 }
 
 // 取得 Google Client ID
-async function getClientId() {
+async function getGoogleClient() {
   try{
     const response = await fetch('/users/js_google_client/')
+
     // 如果取得失敗，則跳轉到錯誤頁面
     if(!response.ok) {
       window.location.href = '/users/error/?type=config_error';
@@ -20,7 +21,7 @@ async function getClientId() {
     }
     // 如果取得成功，則返回 Google Client ID
     const data = await response.json()
-    return data.client_id
+    return data
   }catch(error) {
     // 如果取得失敗，則跳轉到錯誤頁面
     window.location.href = '/users/error/?type=network_error';
@@ -31,29 +32,24 @@ async function getClientId() {
 
 // 觸發 Google OAuth2 Popup 登入
 async function triggerGoogleSignIn() {
-  const clientId = await getClientId();
+  const googleClient = await getGoogleClient();
+
+  if (!googleClient.GOOGLE_CLIENT_ID || !googleClient.HOSTNAME) {
+    console.error('Google 設定無效或不完整:', googleClient);
+    window.location.href = '/users/error/?type=config_error';
+    return;
+  }
+
   if (typeof google !== 'undefined' && google.accounts && google.accounts.oauth2) {
     const client = google.accounts.oauth2.initCodeClient({
-      client_id: clientId,
+      client_id: googleClient.GOOGLE_CLIENT_ID,
       scope: 'email profile openid',
-      ux_mode: 'popup',
-      callback: handleGoogleOAuthResponse
+      ux_mode: 'redirect',
+      redirect_uri: `https://${googleClient.HOSTNAME}/users/social-oauth2/`
     });
     client.requestCode();
   }
 }
-
-// Google OAuth2 Popup 登入處理
-function handleGoogleOAuthResponse(response) {
-  if (response.code) {
-    document.getElementById('google_code').value = response.code;
-    document.getElementById('social_provider').value = 'google';
-    document.getElementById('google-oauth2-form').submit();
-  }else if (response.error) {
-    window.location.href = '/users/error/?type=auth_failed';
-    return;
-  }
-}        
 
 
 export { googleAuth };

--- a/users/templates/users/shared/social_login_buttons.html
+++ b/users/templates/users/shared/social_login_buttons.html
@@ -8,17 +8,12 @@
     </div>
 
     <div class="flex flex-col justify-center gap-4 mt-4">
-        <!-- Google OAuth2 Popup 登入按鈕 -->
-        <form id="google-oauth2-form" action="{% url 'users:social_oauth2' %}" method="post">
-            {% csrf_token %}
-            <input type="hidden" name="google_code" id="google_code">
-            <input type="hidden" name="social_provider" id="social_provider">
-            <button id="google-signin-btn" 
-                class="flex items-center justify-center gap-2 w-full py-2 px-4 border border-[var(--tertiary-color-300)] rounded-full hover:border-[var(--tertiary-color)] hover:bg-[var(--tertiary-color)] transition-colors">
-                <img src="{% static 'assets/google.png' %}" alt="Google" class="w-4 h-4">
-                <span class="text-sm">Google</span>
-            </button>
-        </form>
+        <!-- Google OAuth2 登入按鈕 -->
+        <button id="google-signin-btn" 
+            class="flex items-center justify-center gap-2 w-full py-2 px-4 border border-[var(--tertiary-color-300)] rounded-full hover:border-[var(--tertiary-color)] hover:bg-[var(--tertiary-color)] transition-colors">
+            <img src="{% static 'assets/google.png' %}" alt="Google" class="w-4 h-4">
+            <span class="text-sm">Google</span>
+        </button>
         
         <a href="#" class="flex items-center justify-center gap-2 w-full py-2 px-4 border border-[var(--tertiary-color-300)] rounded-full hover:border-[var(--tertiary-color)] hover:bg-[var(--tertiary-color)] transition-colors">
             <img src="{% static 'assets/line.png' %}" alt="Line" class="w-[18px] h-[18px]">

--- a/users/views.py
+++ b/users/views.py
@@ -25,7 +25,7 @@ from allauth.socialaccount.models import SocialLogin, SocialAccount
 from allauth.socialaccount.helpers import complete_social_login
 from django.http import JsonResponse
 from allauth.exceptions import ImmediateHttpResponse
-
+from django.conf import settings
 from django.http import HttpResponse, HttpRequest
 from allauth.account.views import PasswordResetFromKeyView
 from .forms import CustomResetPasswordFromKeyForm
@@ -49,12 +49,15 @@ def custom_password_reset_from_key(request, uid=None, key=None):
 
 
 def js_google_client(request):
-    return JsonResponse({"client_id": os.getenv("GOOGLE_CLIENT_ID")})
+    return JsonResponse({
+        "GOOGLE_CLIENT_ID": settings.GOOGLE_CLIENT_ID,
+        "HOSTNAME": settings.HOSTNAME,
+    })
 
 
 def handle_error(request):
     error_messages = {
-        "config_error": "系統配置載入失敗，請稍後再試",
+        "config_error": "系統配置載入失敗，請重整頁面後再試",
         "network_error": "網路連線異常，請檢查網路狀態",
         "unknown": "發生未知錯誤，請聯絡客服",
         "auth_failed": "登入取消，請稍後再試",
@@ -534,7 +537,7 @@ def address_cancel(request, address_id):
 # TODO: 接收前端的授權碼進行驗證和登入
 def social_oauth2(request):
     # 先加入調試訊息
-    code = request.POST.get("google_code")
+    code = request.GET.get("code")
 
     if not code:
         messages.error(request, "過程中斷，請重新嘗試")
@@ -548,7 +551,6 @@ def social_oauth2(request):
 
         # 2. 用 access token 取得用戶資料
         user_info = get_user_info(tokens["access_token"])
-
         # 3. 前往登入或註冊
         social_login = create_google_login(user_info)
         return complete_social_login(request, social_login)
@@ -567,11 +569,11 @@ def social_oauth2(request):
 
 
 def token_code_handler(code):
-    # 設定 OAuth 流程
+    # 設定 OAuth 流程    
     client_config = {
         "web": {
-            "client_id": os.getenv("GOOGLE_CLIENT_ID"),
-            "client_secret": os.getenv("GOOGLE_CLIENT_SECRET"),
+            "client_id": settings.GOOGLE_CLIENT_ID,
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,
             "auth_uri": "https://accounts.google.com/o/oauth2/auth",
             "token_uri": "https://oauth2.googleapis.com/token",
         }
@@ -587,7 +589,7 @@ def token_code_handler(code):
     )
 
     # 設定重導向 URI（必須與 Google Console 設定一致）
-    flow.redirect_uri = "postmessage"  # 彈窗模式用這個
+    flow.redirect_uri = f"https://{settings.HOSTNAME}/users/social-oauth2/"
 
     # 用授權碼換取 token
     flow.fetch_token(code=code)


### PR DESCRIPTION
close #239 
- 修改 Google 登入介面，`ux-mode` 從 `pupup` 改成 `redirect`。
- 修改導向流程，登入完直接轉跳首頁。
- 修復 safari 瀏覽器無法作用的問題。
